### PR TITLE
Use req.secure (if set)

### DIFF
--- a/lib/middleware/hsts.js
+++ b/lib/middleware/hsts.js
@@ -12,7 +12,7 @@ module.exports = function (maxAge, includeSubdomains) {
     if (includeSubdomains) header += '; includeSubdomains';
     
     return function (req, res, next)  {
-        if (req.connection.encrypted) {
+        if (typeof req.secure !== "undefined" ? req.secure : req.connection.encrypted) {
             res.header('Strict-Transport-Security', header);
         }
         next();


### PR DESCRIPTION
My req.connection.encrypted is always undefined, so use req.secure (http://expressjs.com/api.html#req.secure) if it is set, it also checks 'X-Forwarded-Proto' header (if the user trusts the proxy, http://expressjs.com/api.html#req.protocol)
