### PR TITLE
Updating iframe action updated to force uppercase

### DIFF
--- a/lib/middleware/xframe.js
+++ b/lib/middleware/xframe.js
@@ -8,12 +8,15 @@
 */
 module.exports = function (action, options) {
     var header = 'DENY';
-    if (action == 'sameorigin') {
+
+    action = action.toUpperCase();
+
+    if (action == 'SAMEORIGIN') {
         header = 'SAMEORIGIN';
-    } else if ((action == 'allow-from' || action == 'allowfrom') && options) {
+    } else if ((action == 'ALLOW-FROM' || action == 'ALLOWFROM') && options) {
         header = 'ALLOW-FROM ' + options;
     }
-    
+
     return function (req, res, next)  {
         res.header('X-FRAME-OPTIONS', header);
         next();


### PR DESCRIPTION
The action passed into the xframe method is lowercase while the action detailed in the spec is uppercase. This is confusing when using the spec as a guide. 

This converts any action string passed to uppercase so that "sameorigin" and "SAMEORIGIN" will both work.
