### PR TITLE
Make helmet easier to find on npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "helmet",
   "description": "Security header middleware collection for express",
   "version": "0.0.9",
-  "keywords": ["security", "headers", "express", "x-frame-options", "csp"],
+  "keywords": ["security", "headers", "express", "x-frame-options", "csp", "hsts"],
   "repository": {
     "url": "git://github.com/evilpacket/helmet.git"
   },


### PR DESCRIPTION
I searched for `hsts` using the npm cli and did not find it. https://npmjs.org/search?q=hsts works fine though, so I think adding `hsts` to the keywords section will make it a bit easier to find.

Thanks for saving me time :+1: 
