### PR TITLE
Hide X-Powered-By header

### DIFF
--- a/lib/middleware/hidePoweredBy.js
+++ b/lib/middleware/hidePoweredBy.js
@@ -1,0 +1,8 @@
+/* Remove the X-Powered-By header if present
+*/
+module.exports = function () {
+    return function (req, res, next) {
+        res.removeHeader('X-Powered-By');
+        next();
+    };
+};

--- a/test/hidePoweredBy.js
+++ b/test/hidePoweredBy.js
@@ -1,0 +1,26 @@
+var helmet = require('../');
+var assert = require('assert');
+var sinon = require('sinon');
+
+describe('hidePoweredBy', function () {
+
+    var req, res, next, middleware;
+    beforeEach(function () {
+        middleware = helmet.hidePoweredBy();
+        res = { removeHeader: sinon.spy() };
+        next = sinon.spy();
+    });
+
+    afterEach(function () {
+        assert(next.calledOnce);
+    });
+
+    it('removes the X-Powered-By header', function () {
+        middleware(req, res, next);
+        assert(res.removeHeader.calledOnce);
+        var args = res.removeHeader.firstCall.args;
+        assert(args.length == 1);
+        assert(args[0].toLowerCase() == 'x-powered-by');
+    });
+
+});


### PR DESCRIPTION
Express (and possibly other Connect-based libraries) will, by default, send an HTTP header called `X-Powered-By`. If exploits in Express are found, this information could be used by an attacker.

Perhaps worth a version bump and/or an inclusion in `helmet.defaults`.
