### PR TITLE
Support helmet.defaults() as middleware, fixes #13

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -12,7 +12,7 @@ fs.readdirSync(__dirname + '/middleware').forEach(function (filename) {
 });
 
 exports.defaults = function (app, overrides) {
-    if (typeof app.use !== 'function') {
+    if (!app || typeof app.use !== 'function') {
         overrides = app;
         try {   // make sub-app, in likeliest framework(s)
             app = require('express')();


### PR DESCRIPTION
Here's a simple way to support both the old and more conventional middleware-like usage of `helmet.defaults()`.

NOTE: there's one caveat in that the user _must_ be using (i.e. have installed) either 'express' or 'connect' themselves but that seemed a reasonable enough assumption, eh?
