### PR TITLE
Do not send CSP for Android Browser < 4.4.

### DIFF
--- a/lib/middleware/csp.js
+++ b/lib/middleware/csp.js
@@ -195,6 +195,9 @@ module.exports = function csp(options) {
       }
       break;
 
+      case 'Android Browser':
+      break;
+
       default:
         setAllHeaders = true;
 


### PR DESCRIPTION
Android Browser < 4.4 doesn't simply silently fail when CSP headers are sent, as one might expect. It just doesn't load _any_ resources.