### PR TITLE
Add license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,5 +47,6 @@
   "scripts": {
     "test": "mocha"
   },
+  "license": "MIT",
   "main": "index"
 }


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/