### PR TITLE
Add a note about testing HPKP

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,7 +350,10 @@ app.use(helmet.hpkp({
 
 Setting `reportOnly` to `true` will change the header from `Public-Key-Pins` to `Public-Key-Pins-Report-Only`.
 
-**Limitations:** Don't let these get out of sync with your certs!
+**Limitations:** Don't let these get out of sync with your certs! It's
+  also recommended to test your HPKP deployment in `reportOnly` mode,
+  or alternatively, to use a very short `maxAge` until you're
+  confident your deployment is correct.
 
 ### Prevent DNS prefetching: dnsPrefetchControl
 


### PR DESCRIPTION
This adds a brief recommendation to test HPKP in `report-only` mode or with a short `max-age`.