### PR TITLE
Update to connect v3.6.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "node": ">= 0.10.0"
   },
   "dependencies": {
-    "connect": "3.6.0",
+    "connect": "3.6.2",
     "dns-prefetch-control": "0.1.0",
     "dont-sniff-mimetype": "1.0.0",
     "expect-ct": "0.1.0",


### PR DESCRIPTION
This will fix a ReDoS issue in debug@2.6.1 -> ms@0.7.2. Connect v3.6.2 upgraded to debug@2.6.7, which uses ms@2.0.0 with a fix for the ReDoS vulnerability.

More details available at: https://snyk.io/test/npm/helmet/3.6.0 