### PR TITLE
Warn if a helmet constructor is used directly as handler

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,10 @@ var middlewares
 function helmet (options) {
   options = options || {}
 
+  if (options.constructor.name === 'IncomingMessage') {
+    throw new Error('you must call helmet() when using it in your app')
+  }
+
   var chain = connect()
 
   middlewares.forEach(function (middlewareName) {


### PR DESCRIPTION
Not sure if this is something you'd consider helpful, but I just did `app.use(helmet)` by itself and was confused for a minute why my requests were timing out. More of a friendly reminder of usage.

Should be fully backwards compatible and not affect anyone using Helmet properly.