### PR TITLE
make next optional

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ function helmet (options) {
       if (arguments.length > 0) { return next.apply(null, arguments) }
 
       var middleware = stack[index]
-      if (!middleware) { return next() }
+      if (!middleware) { return next && next() }
 
       index++
 


### PR DESCRIPTION
When using helmet outside of connect or express it would be nice to be able to avoid passing a `next` callback. Since everything is synchronous this should be a valid use case. 