### PR TITLE
Use sinon's default sandbox feature

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -6,12 +6,8 @@ const connect = require('connect')
 const request = require('supertest')
 
 describe('helmet', function () {
-  beforeEach(function () {
-    this.sandbox = sinon.createSandbox()
-  })
-
   afterEach(function () {
-    this.sandbox.restore()
+    sinon.restore()
   })
 
   describe('module aliases', function () {
@@ -107,9 +103,9 @@ describe('helmet', function () {
     beforeEach(function () {
       Object.keys(helmet).forEach(function (key) {
         if (typeof helmet[key] === 'function') {
-          this.sandbox.spy(helmet, key)
+          sinon.spy(helmet, key)
         }
-      }.bind(this))
+      })
     })
 
     it('chains all default middleware', function () {


### PR DESCRIPTION
Since `sinon@5.0.0`, the `sinon` object is a default sandbox. This means
that we can reduce the number of lines required to set up the tests.

See: https://sinonjs.org/releases/v7.4.1/sandbox/#default-sandbox