### PR TITLE
Deprecate Feature-Policy

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -127,7 +127,6 @@ function helmet(options: Readonly<HelmetOptions> = {}) {
 helmet.contentSecurityPolicy = require("helmet-csp");
 helmet.dnsPrefetchControl = require("dns-prefetch-control");
 helmet.expectCt = require("expect-ct");
-helmet.featurePolicy = require("feature-policy");
 helmet.frameguard = require("frameguard");
 helmet.hidePoweredBy = require("hide-powered-by");
 helmet.hsts = require("hsts");
@@ -137,6 +136,10 @@ helmet.permittedCrossDomainPolicies = require("helmet-crossdomain");
 helmet.referrerPolicy = require("referrer-policy");
 helmet.xssFilter = require("x-xss-protection");
 
+helmet.featurePolicy = deprecate.function(
+  require("feature-policy"),
+  "helmet.featurePolicy is deprecated (along with the HTTP header) and will be removed in helmet@4. You can use the `feature-policy` module instead."
+);
 helmet.hpkp = deprecate.function(
   require("hpkp"),
   "helmet.hpkp is deprecated and will be removed in helmet@4. You can use the `hpkp` module instead. For more, see https://github.com/helmetjs/helmet/issues/180."

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -21,9 +21,35 @@ describe("helmet", function () {
       expect(helmet.expectCt).toBe(pkg);
     });
 
-    it('aliases "feature-policy"', function () {
-      const pkg = require("feature-policy");
-      expect(helmet.featurePolicy).toBe(pkg);
+    // This test will be removed in helmet@4.
+    it("calls through to feature-policy but emits a deprecation warning", function () {
+      const deprecationPromise = new Promise((resolve) => {
+        process.once("deprecation", (deprecationError) => {
+          expect(
+            deprecationError.message.indexOf(
+              "You can use the `feature-policy` module instead."
+            ) !== -1
+          ).toBeTruthy();
+          resolve();
+        });
+      });
+
+      const app = connect();
+      app.use(
+        helmet.featurePolicy({
+          features: { vibrate: ["'none'"] },
+        })
+      );
+      app.use((_req: IncomingMessage, res: ServerResponse) => {
+        res.end("Hello world!");
+      });
+      const supertestPromise = request(app)
+        .get("/")
+        .expect(200)
+        .expect("Feature-Policy", "vibrate 'none'")
+        .expect("Hello world!");
+
+      return Promise.all([deprecationPromise, supertestPromise]);
     });
 
     it('aliases "helmet-crossdomain"', function () {


### PR DESCRIPTION
Feature Policy has been deprecated in favor of "Permissions Policy" (see [the draft spec](https://w3c.github.io/webappsec-feature-policy/)).

I intend to merge and deploy this on June 12, 2020 (two days from now).