### PR TITLE
HelmetOptions update

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -23,7 +23,7 @@ import xPermittedCrossDomainPolicies, {
 import xPoweredBy from "./middlewares/x-powered-by";
 import xXssProtection from "./middlewares/x-xss-protection";
 
-interface HelmetOptions {
+export interface HelmetOptions {
   contentSecurityPolicy?: MiddlewareOption<ContentSecurityPolicyOptions>;
   dnsPrefetchControl?: MiddlewareOption<XDnsPrefetchControlOptions>;
   expectCt?: MiddlewareOption<ExpectCtOptions>;


### PR DESCRIPTION
exporting HelmetOptions for 3rd part libs to be able to extend from it.
for example https://github.com/fastify/fastify-helmet is failing because the interface is not available for importing to other libs/projects..