### PR TITLE
Remove options.hsts === true

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -101,7 +101,7 @@ function helmet(options: Readonly<HelmetOptions> = {}) {
     middlewareFunctions.push(xPoweredBy());
   }
 
-  if (options.hsts === undefined || options.hsts === true) {
+  if (options.hsts === undefined) {
     middlewareFunctions.push(strictTransportSecurity());
   } else if (options.hsts !== false) {
     middlewareFunctions.push(strictTransportSecurity(options.hsts));


### PR DESCRIPTION
I don't think `options.hsts === true` can ever occur here, since you throw an error above if any of the values in `options` are set to `true`:

https://github.com/helmetjs/helmet/blob/master/index.ts#L61-L65

Am I misreading this?