### PR TITLE
put max age first in expect-ct middleware

### DIFF
--- a/middlewares/expect-ct/index.ts
+++ b/middlewares/expect-ct/index.ts
@@ -27,11 +27,11 @@ function parseMaxAge(value: void | number): number {
 function getHeaderValueFromOptions(options: Readonly<ExpectCtOptions>): string {
   const directives: string[] = [];
 
+  directives.push(`max-age=${parseMaxAge(options.maxAge)}`);
+
   if (options.enforce) {
     directives.push("enforce");
   }
-
-  directives.push(`max-age=${parseMaxAge(options.maxAge)}`);
 
   if (options.reportUri) {
     directives.push(`report-uri="${options.reportUri}"`);

--- a/test/expect-ct.test.ts
+++ b/test/expect-ct.test.ts
@@ -43,7 +43,7 @@ describe("Expect-CT middleware", () => {
 
   it("can enable enforcement", async () => {
     await check(expectCt({ enforce: true }), {
-      "expect-ct": "enforce, max-age=0",
+      "expect-ct": "max-age=0, enforce",
     });
   });
 
@@ -68,7 +68,7 @@ describe("Expect-CT middleware", () => {
       }),
       {
         "expect-ct":
-          'enforce, max-age=123, report-uri="https://example.com/report"',
+          'max-age=123, enforce, report-uri="https://example.com/report"',
       }
     );
   });


### PR DESCRIPTION
Updated `expect-ct -> getHeaderValueFromOptions` method where there was necessary to put max-age property as first in directives.

Updated `expect-ct.test.ts`