### PR TITLE
[CSP] Export the default directives to allow for easier overloading

### DIFF
--- a/middlewares/content-security-policy/index.ts
+++ b/middlewares/content-security-policy/index.ts
@@ -191,5 +191,13 @@ function contentSecurityPolicy(
   };
 }
 
+/**
+ * Expose the default directives
+ *
+ * If the internal default directives structure is ever changed,
+ * i.e. a to a string, this would have to parse them to the external interface object structure
+ */
+contentSecurityPolicy.getDefaultDirectives = () => DEFAULT_DIRECTIVES;
+
 module.exports = contentSecurityPolicy;
 export default contentSecurityPolicy;


### PR DESCRIPTION
If you only want to change one of the, out of the box (default), CSP directives. You are expected to copy the current [`DEFAULT_DIRECTIVES`](https://github.com/helmetjs/helmet/blob/53e31738d4d23ea3879e5f2b189622e8d8348f71/middlewares/content-security-policy/index.ts#L20) and change them as your needs require.

This PR just exports the `DEFAULT_DIRECTIVES` ensuring an easier dev experience...

i.e. instead of having to do;

````typescript
helmet({
  contentSecurityPolicy: {
    directives: {
      // copied from DEFAULT_DIRECTIVES https://github.com/helmetjs/helmet/blob/53e31738d4d23ea3879e5f2b189622e8d8348f71/middlewares/content-security-policy/index.ts#L20
      "default-src": ["'self'"],
      "base-uri": ["'self'"],
      "block-all-mixed-content": [],
      "font-src": ["'self'", "https:", "data:"],
      "frame-ancestors": ["'self'"],
      "img-src": ["'self'", "data:"],
      "object-src": ["'none'"],
      "script-src": ["'self'", "'unsafe-inline'"], // <- this is non default
      "script-src-attr": ["'none'"],
      "style-src": ["'self'", "https:", "'unsafe-inline'"],
      "upgrade-insecure-requests": [],
    },
  },
})
````

We can now do something like the following:

Override a directive

````typescript
import { DEFAULT_DIRECTIVES } from "helmet/dist/middlewares/content-security-policy";

helmet({
  contentSecurityPolicy: {
    directives: {
      ...DEFAULT_DIRECTIVES,
      "script-src": ["'self'", "'unsafe-inline'"], // <- this is non default
    },
  },
})
````

Extend a directive

````typescript
import { DEFAULT_DIRECTIVES } from "helmet/dist/middlewares/content-security-policy";

helmet({
  contentSecurityPolicy: {
    directives: {
      ...DEFAULT_DIRECTIVES,
      "script-src": [
        ...DEFAULT_DIRECTIVES["script-src"], 
        "'unsafe-inline'" // <- this is non default
      ],
    },
  },
})
````

Due to the simplicity of the change I did not see the need to add tests.

Let me know if I have missed something and/or tests are required!


A possible enhancement would be to export the CSP defaults directly;

````typescript
import { CSP_DEFAULT_DIRECTIVES } from "helmet";
````

