### PR TITLE
Fix nonce example arrow function in Readme

### DIFF
--- a/middlewares/content-security-policy/README.md
+++ b/middlewares/content-security-policy/README.md
@@ -37,7 +37,7 @@ You can dynamically generate nonces to allow inline `<script>` tags to be safely
 ```js
 const crypto = require("crypto");
 
-app.use((req, res, next) {
+app.use((req, res, next) => {
   res.locals.nonce = crypto.randomBytes(16).toString("hex");
   next();
 });


### PR DESCRIPTION
Fixed the nonce example in the Readme. Should be an arrow function.