### PR TITLE
Content-Security-Policy: add `getDefaultDirectives()` helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- `helmet.contentSecurityPolicy`: get the default directives with `contentSecurityPolicy.getDefaultDirectives()`
+
 ### Changed
 
 - `helmet.expectCt`: `max-age` is now first. See [#264](https://github.com/helmetjs/helmet/pull/264)

--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ If no directives are supplied, the following policy is set (whitespace added for
     style-src 'self' https: 'unsafe-inline';
     upgrade-insecure-requests
 
+You can fetch this default with `helmet.contentSecurityPolicy.getDefaultDirectives()`.
+
 Examples:
 
 ```js
@@ -159,6 +161,16 @@ app.use(
       "default-src": ["'self'"],
       "script-src": ["'self'", "example.com"],
       "object-src": ["'none'"],
+    },
+  })
+);
+
+// Sets all of the defaults, but overrides script-src
+app.use(
+  helmet.contentSecurityPolicy({
+    directives: {
+      ...helmet.contentSecurityPolicy.getDefaultDirectives(),
+      "script-src": ["'self'", "example.com"],
     },
   })
 );

--- a/middlewares/content-security-policy/CHANGELOG.md
+++ b/middlewares/content-security-policy/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- Get the default directives with `contentSecurityPolicy.getDefaultDirectives()`
+
 ## 3.1.0 - 2020-08-15
 
 ### Added

--- a/middlewares/content-security-policy/README.md
+++ b/middlewares/content-security-policy/README.md
@@ -9,10 +9,10 @@ This middleware helps set Content Security Policies.
 Basic usage:
 
 ```javascript
-const csp = require("helmet-csp");
+const contentSecurityPolicy = require("helmet-csp");
 
 app.use(
-  csp({
+  contentSecurityPolicy({
     directives: {
       defaultSrc: ["'self'", "default.example"],
       scriptSrc: ["'self'", "'unsafe-inline'"],
@@ -23,6 +23,8 @@ app.use(
   })
 );
 ```
+
+To get the defaults, use `contentSecurityPolicy.getDefaultDirectives()`.
 
 You can set any directives you wish. `defaultSrc` is required. Directives can be kebab-cased (like `script-src`) or camel-cased (like `scriptSrc`). They are equivalent, but duplicates are not allowed.
 

--- a/middlewares/content-security-policy/index.ts
+++ b/middlewares/content-security-policy/index.ts
@@ -31,6 +31,8 @@ const DEFAULT_DIRECTIVES: ContentSecurityPolicyDirectives = {
   "upgrade-insecure-requests": [],
 };
 
+const getDefaultDirectives = () => ({ ...DEFAULT_DIRECTIVES });
+
 const isRawPolicyDirectiveNameInvalid = (rawDirectiveName: string): boolean =>
   rawDirectiveName.length === 0 || /[^a-zA-Z0-9-]/.test(rawDirectiveName);
 
@@ -58,7 +60,7 @@ function normalizeDirectives(
 ): ContentSecurityPolicyDirectives {
   const result: ContentSecurityPolicyDirectives = {};
 
-  const { directives: rawDirectives = DEFAULT_DIRECTIVES } = options;
+  const { directives: rawDirectives = getDefaultDirectives() } = options;
 
   for (const rawDirectiveName in rawDirectives) {
     if (!has(rawDirectives, rawDirectiveName)) {
@@ -190,6 +192,8 @@ function contentSecurityPolicy(
     }
   };
 }
+contentSecurityPolicy.getDefaultDirectives = getDefaultDirectives;
 
 module.exports = contentSecurityPolicy;
 export default contentSecurityPolicy;
+export { getDefaultDirectives };

--- a/test/content-security-policy.test.ts
+++ b/test/content-security-policy.test.ts
@@ -2,7 +2,9 @@ import { IncomingMessage, ServerResponse } from "http";
 import { check } from "./helpers";
 import connect = require("connect");
 import supertest = require("supertest");
-import contentSecurityPolicy from "../middlewares/content-security-policy";
+import contentSecurityPolicy, {
+  getDefaultDirectives,
+} from "../middlewares/content-security-policy";
 
 async function checkCsp({
   middlewareArgs,
@@ -409,5 +411,29 @@ describe("Content-Security-Policy middleware", () => {
         "Content-Security-Policy middleware no longer does browser sniffing, so you can remove the `browserSniff` option. See <https://github.com/helmetjs/csp/issues/97> for discussion."
       );
     });
+  });
+});
+
+describe("getDefaultDirectives", () => {
+  it("returns the middleware's default directives", () => {
+    expect(getDefaultDirectives()).toEqual({
+      "base-uri": ["'self'"],
+      "block-all-mixed-content": [],
+      "default-src": ["'self'"],
+      "font-src": ["'self'", "https:", "data:"],
+      "frame-ancestors": ["'self'"],
+      "img-src": ["'self'", "data:"],
+      "object-src": ["'none'"],
+      "script-src": ["'self'"],
+      "script-src-attr": ["'none'"],
+      "style-src": ["'self'", "https:", "'unsafe-inline'"],
+      "upgrade-insecure-requests": [],
+    });
+  });
+
+  it("attaches itself to the top-level function", () => {
+    expect(getDefaultDirectives).toBe(
+      contentSecurityPolicy.getDefaultDirectives
+    );
   });
 });


### PR DESCRIPTION
This adds a new helper, `helmet.contentSecurityPolicy.getDefaultDirectives()`, which returns the default directives. You might use this to only override a single default, like so:

```js
// Sets all of the defaults, but overrides script-src
app.use(
  helmet.contentSecurityPolicy({
    directives: {
      ...helmet.contentSecurityPolicy.getDefaultDirectives(),
      "script-src": ["'self'", "example.com"],
    },
  })
);
```

I plan to solicit feedback on this for a short period before merging and releasing this.