### PR TITLE
Content-Security-Policy: allow `default-src` to be disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- `helmet.contentSecurityPolicy`: setting the `default-src` to `helmet.contentSecurityPolicy.dangerouslyDisableDefaultSrc` disables it
+
 ### Changed
 
 - `helmet.frameguard`: slightly improved error messages for non-strings

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Each middleware's name is listed below.
 
 This middleware performs very little validation. You should rely on CSP checkers like [CSP Evaluator](https://csp-evaluator.withgoogle.com/) instead.
 
-`options.directives` is an object. Each key is a directive name in camel case (such as `defaultSrc`) or kebab case (such as `default-src`). Each value is an iterable (usually an array) of strings or functions for that directive. If a function appears in the iterable, it will be called with the request and response.
+`options.directives` is an object. Each key is a directive name in camel case (such as `defaultSrc`) or kebab case (such as `default-src`). Each value is an iterable (usually an array) of strings or functions for that directive. If a function appears in the iterable, it will be called with the request and response. The `default-src` can be explicitly disabled by setting its value to `helmet.contentSecurityPolicy.dangerouslyDisableDefaultSrc`.
 
 `options.reportOnly` is a boolean, defaulting to `false`. If `true`, [the `Content-Security-Policy-Report-Only` header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy-Report-Only) will be set instead.
 
@@ -195,6 +195,16 @@ app.use(
     directives: {
       defaultSrc: ["'self'"],
       scriptSrc: ["'self'", (req, res) => `'nonce-${res.locals.cspNonce}'`],
+    },
+  })
+);
+
+// Sets "Content-Security-Policy: script-src 'self'"
+app.use(
+  helmet.contentSecurityPolicy({
+    directives: {
+      "default-src": helmet.contentSecurityPolicy.dangerouslyDisableDefaultSrc,
+      "script-src": ["'self'"],
     },
   })
 );

--- a/middlewares/content-security-policy/CHANGELOG.md
+++ b/middlewares/content-security-policy/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- Setting the `default-src` to `contentSecurityPolicy.dangerouslyDisableDefaultSrc` disables it
+
 ## 3.2.0 - 2020-11-01
 
 ### Added

--- a/middlewares/content-security-policy/README.md
+++ b/middlewares/content-security-policy/README.md
@@ -26,7 +26,7 @@ app.use(
 
 To get the defaults, use `contentSecurityPolicy.getDefaultDirectives()`.
 
-You can set any directives you wish. `defaultSrc` is required. Directives can be kebab-cased (like `script-src`) or camel-cased (like `scriptSrc`). They are equivalent, but duplicates are not allowed.
+You can set any directives you wish. `defaultSrc` is required, but can be explicitly disabled by setting its value to `contentSecurityPolicy.dangerouslyDisableDefaultSrc`. Directives can be kebab-cased (like `script-src`) or camel-cased (like `scriptSrc`). They are equivalent, but duplicates are not allowed.
 
 The `reportOnly` option, if set to `true`, sets the `Content-Security-Policy-Report-Only` header instead.
 


### PR DESCRIPTION
This lets you disable `default-src`, like this:

```js
app.use(
  helmet.contentSecurityPolicy({
    directives: {
      defaultSrc: helmet.contentSecurityPolicy.dangerouslyDisableDefaultSrc,
      // ...
    },
  })
);
```

I'll plan to merge this in a few days, barring objection.

Closes #237.