### PR TITLE
Content-Security-Policy: useDefaults option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- `helmet.contentSecurityPolicy`: the `useDefaults` option, defaulting to `false`, lets you selectively override defaults more easily
+
 ## 4.5.0 - 2021-04-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -136,14 +136,28 @@ If no directives are supplied, the following policy is set (whitespace added for
     style-src 'self' https: 'unsafe-inline';
     upgrade-insecure-requests
 
-You can fetch this default with `helmet.contentSecurityPolicy.getDefaultDirectives()`.
+You can use this default with the `options.useDefaults` option. `options.useDefaults` is `false` by default, but will be `true` in the next major version of Helmet.
+
+You can also get the default directives object with `helmet.contentSecurityPolicy.getDefaultDirectives()`.
 
 Examples:
 
 ```js
+// Sets all of the defaults, but overrides `script-src` and disables the default `style-src`
+app.use(
+  helmet.contentSecurityPolicy({
+    useDefaults: true,
+    directives: {
+      "script-src": ["'self'", "example.com"],
+      "style-src": null,
+    },
+  })
+);
+
 // Sets "Content-Security-Policy: default-src 'self';script-src 'self' example.com;object-src 'none';upgrade-insecure-requests"
 app.use(
   helmet.contentSecurityPolicy({
+    useDefaults: false,
     directives: {
       defaultSrc: ["'self'"],
       scriptSrc: ["'self'", "example.com"],
@@ -153,30 +167,10 @@ app.use(
   })
 );
 
-// Sets "Content-Security-Policy: default-src 'self';script-src 'self' example.com;object-src 'none'"
-app.use(
-  helmet.contentSecurityPolicy({
-    directives: {
-      "default-src": ["'self'"],
-      "script-src": ["'self'", "example.com"],
-      "object-src": ["'none'"],
-    },
-  })
-);
-
-// Sets all of the defaults, but overrides script-src
-app.use(
-  helmet.contentSecurityPolicy({
-    directives: {
-      ...helmet.contentSecurityPolicy.getDefaultDirectives(),
-      "script-src": ["'self'", "example.com"],
-    },
-  })
-);
-
 // Sets the "Content-Security-Policy-Report-Only" header instead
 app.use(
   helmet.contentSecurityPolicy({
+    useDefaults: true,
     directives: {
       /* ... */
     },
@@ -184,15 +178,15 @@ app.use(
   })
 );
 
-// Sets "Content-Security-Policy: default-src 'self';script-src 'self' 'nonce-e33ccde670f149c1789b1e1e113b0916'"
+// Sets the `script-src` directive to "'self' 'nonce-e33ccde670f149c1789b1e1e113b0916'" (or similar)
 app.use((req, res, next) => {
   res.locals.cspNonce = crypto.randomBytes(16).toString("hex");
   next();
 });
 app.use(
   helmet.contentSecurityPolicy({
+    useDefaults: true,
     directives: {
-      defaultSrc: ["'self'"],
       scriptSrc: ["'self'", (req, res) => `'nonce-${res.locals.cspNonce}'`],
     },
   })
@@ -201,6 +195,7 @@ app.use(
 // Sets "Content-Security-Policy: script-src 'self'"
 app.use(
   helmet.contentSecurityPolicy({
+    useDefaults: false,
     directives: {
       "default-src": helmet.contentSecurityPolicy.dangerouslyDisableDefaultSrc,
       "script-src": ["'self'"],

--- a/middlewares/content-security-policy/CHANGELOG.md
+++ b/middlewares/content-security-policy/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- New `useDefaults` option, defaulting to `false`, lets you selectively override defaults more easily
+
 ## 3.3.1 - 2020-12-27
 
 ### Fixed

--- a/middlewares/content-security-policy/README.md
+++ b/middlewares/content-security-policy/README.md
@@ -13,9 +13,10 @@ const contentSecurityPolicy = require("helmet-csp");
 
 app.use(
   contentSecurityPolicy({
+    useDefaults: true,
     directives: {
       defaultSrc: ["'self'", "default.example"],
-      scriptSrc: ["'self'", "'unsafe-inline'"],
+      scriptSrc: ["'self'", "js.example.com"],
       objectSrc: ["'none'"],
       upgradeInsecureRequests: [],
     },
@@ -24,7 +25,23 @@ app.use(
 );
 ```
 
-To get the defaults, use `contentSecurityPolicy.getDefaultDirectives()`.
+If no directives are supplied, the following policy is set (whitespace added for readability):
+
+    default-src 'self';
+    base-uri 'self';
+    block-all-mixed-content;
+    font-src 'self' https: data:;
+    frame-ancestors 'self';
+    img-src 'self' data:;
+    object-src 'none';
+    script-src 'self';
+    script-src-attr 'none';
+    style-src 'self' https: 'unsafe-inline';
+    upgrade-insecure-requests
+
+You can use this default with the `useDefaults` option. `useDefaults` is `false` by default, but will be `true` in the next major version of this module.
+
+You can also get the default directives object with `contentSecurityPolicy.getDefaultDirectives()`.
 
 You can set any directives you wish. `defaultSrc` is required, but can be explicitly disabled by setting its value to `contentSecurityPolicy.dangerouslyDisableDefaultSrc`. Directives can be kebab-cased (like `script-src`) or camel-cased (like `scriptSrc`). They are equivalent, but duplicates are not allowed.
 
@@ -46,8 +63,8 @@ app.use((req, res, next) => {
 
 app.use((req, res, next) => {
   csp({
+    useDefaults: true,
     directives: {
-      defaultSrc: ["'self'"],
       scriptSrc: ["'self'", `'nonce-${res.locals.nonce}'`],
     },
   })(req, res, next);


### PR DESCRIPTION
See the changelog and README for a summary of the new interface. In short, you can now do this:

```js
app.use(
  helmet.contentSecurityPolicy({
    useDefaults: true,
    directives: {
      styleSrc: ["'self'", 'example.com'],
    },
  })
);
```

See #289 for background.