### PR TITLE
Enable middlewares by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- `helmet.crossOriginEmbedderPolicy`: enabled by default
+- `helmet.crossOriginOpenerPolicy`: enabled by default
+- `helmet.crossOriginResourcePolicy`: enabled by default
+- `helmet.originAgentCluster`: enabled by default
+- Updated tests in `index.test.ts` to reflect the above middlewares being enabled by default
+
 ## 4.6.0 - 2021-05-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,5 @@
 # Changelog
 
-## Unreleased
-
-### Added
-
-- `helmet.crossOriginEmbedderPolicy`: enabled by default
-- `helmet.crossOriginOpenerPolicy`: enabled by default
-- `helmet.crossOriginResourcePolicy`: enabled by default
-- `helmet.originAgentCluster`: enabled by default
-- Updated tests in `index.test.ts` to reflect the above middlewares being enabled by default
-
 ## 4.6.0 - 2021-05-01
 
 ### Added

--- a/index.ts
+++ b/index.ts
@@ -139,23 +139,19 @@ function getMiddlewareFunctionsFromOptions(
     {
       name: "crossOriginEmbedderPolicy",
       takesOptions: false,
-      enabledByDefault: false,
     }
   );
   if (crossOriginEmbedderPolicyArgs) {
     result.push(crossOriginEmbedderPolicy());
   }
 
-  const crossOriginOpenerPolicyArgs = getArgs(options.crossOriginOpenerPolicy, {
-    enabledByDefault: false,
-  });
+  const crossOriginOpenerPolicyArgs = getArgs(options.crossOriginOpenerPolicy);
   if (crossOriginOpenerPolicyArgs) {
     result.push(crossOriginOpenerPolicy(...crossOriginOpenerPolicyArgs));
   }
 
   const crossOriginResourcePolicyArgs = getArgs(
-    options.crossOriginResourcePolicy,
-    { enabledByDefault: false }
+    options.crossOriginResourcePolicy
   );
   if (crossOriginResourcePolicyArgs) {
     result.push(crossOriginResourcePolicy(...crossOriginResourcePolicyArgs));
@@ -208,7 +204,6 @@ function getMiddlewareFunctionsFromOptions(
   const originAgentClusterArgs = getArgs(options.originAgentCluster, {
     name: "originAgentCluster",
     takesOptions: false,
-    enabledByDefault: false,
   });
   if (originAgentClusterArgs) {
     result.push(originAgentCluster());

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -157,6 +157,12 @@ describe("helmet", () => {
     });
   });
 
+  it("allows Origin-Agent-Cluster middleware to be enabled", async () => {
+    await check(helmet({ originAgentCluster: true }), {
+      "origin-agent-cluster": "?1",
+    });
+  });
+
   it("allows Origin-Agent-Cluster middleware to be explicitly disabled", async () => {
     await check(helmet({ originAgentCluster: false }), {
       "origin-agent-cluster": null,

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -29,11 +29,11 @@ describe("helmet", () => {
     const expectedHeaders = {
       "content-security-policy":
         "default-src 'self';base-uri 'self';block-all-mixed-content;font-src 'self' https: data:;frame-ancestors 'self';img-src 'self' data:;object-src 'none';script-src 'self';script-src-attr 'none';style-src 'self' https: 'unsafe-inline';upgrade-insecure-requests",
-      "cross-origin-embedder-policy": null,
-      "cross-origin-opener-policy": null,
-      "cross-origin-resource-policy": null,
+      "cross-origin-embedder-policy": "require-corp",
+      "cross-origin-opener-policy": "same-origin",
+      "cross-origin-resource-policy": "same-origin",
       "expect-ct": "max-age=0",
-      "origin-agent-cluster": null,
+      "origin-agent-cluster": "?1",
       "referrer-policy": "no-referrer",
       "strict-transport-security": "max-age=15552000; includeSubDomains",
       "x-content-type-options": "nosniff",
@@ -74,6 +74,7 @@ describe("helmet", () => {
         permittedCrossDomainPolicies: false,
         referrerPolicy: false,
         xssFilter: false,
+        crossOriginEmbedderPolicy: false,
       }),
       {
         "content-security-policy": null,
@@ -100,13 +101,7 @@ describe("helmet", () => {
     });
   });
 
-  it("allows Cross-Origin-Embedder-Policy middleware to be enabled", async () => {
-    await check(helmet({ crossOriginEmbedderPolicy: true }), {
-      "cross-origin-embedder-policy": "require-corp",
-    });
-  });
-
-  it("allows Cross-Origin-Embedder-Policy middleware to be explicitly disabled (a no-op, because it is disabled by default)", async () => {
+  it("allows Cross-Origin-Embedder-Policy middleware to be explicitly disabled", async () => {
     await check(helmet({ crossOriginEmbedderPolicy: false }), {
       "cross-origin-embedder-policy": null,
     });
@@ -129,7 +124,7 @@ describe("helmet", () => {
     );
   });
 
-  it("allows Cross-Origin-Opener-Policy middleware to be explicitly disabled (a no-op, because it is disabled by default)", async () => {
+  it("allows Cross-Origin-Opener-Policy middleware to be explicitly disabled", async () => {
     await check(helmet({ crossOriginOpenerPolicy: false }), {
       "cross-origin-opener-policy": null,
     });
@@ -150,19 +145,13 @@ describe("helmet", () => {
     );
   });
 
-  it("allows Cross-Origin-Resource-Policy middleware to be explicitly disabled (a no-op, because it is disabled by default)", async () => {
+  it("allows Cross-Origin-Resource-Policy middleware to be explicitly disabled", async () => {
     await check(helmet({ crossOriginResourcePolicy: false }), {
       "cross-origin-resource-policy": null,
     });
   });
 
-  it("allows Origin-Agent-Cluster middleware to be enabled", async () => {
-    await check(helmet({ originAgentCluster: true }), {
-      "origin-agent-cluster": "?1",
-    });
-  });
-
-  it("allows Origin-Agent-Cluster middleware to be explicitly disabled (a no-op, because it is disabled by default)", async () => {
+  it("allows Origin-Agent-Cluster middleware to be explicitly disabled", async () => {
     await check(helmet({ originAgentCluster: false }), {
       "origin-agent-cluster": null,
     });
@@ -209,7 +198,7 @@ describe("helmet", () => {
 
       expect(console.warn).toHaveBeenCalledTimes(1);
       expect(console.warn).toHaveBeenCalledWith(
-        "crossOriginEmbedderPolicy does not take options. Set the property to `true` to silence this warning."
+        "crossOriginEmbedderPolicy does not take options. Remove the property to silence this warning."
       );
     });
 
@@ -236,7 +225,7 @@ describe("helmet", () => {
 
       expect(console.warn).toHaveBeenCalledTimes(1);
       expect(console.warn).toHaveBeenCalledWith(
-        "originAgentCluster does not take options. Set the property to `true` to silence this warning."
+        "originAgentCluster does not take options. Remove the property to silence this warning."
       );
     });
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -101,6 +101,12 @@ describe("helmet", () => {
     });
   });
 
+  it("allows Cross-Origin-Embedder-Policy middleware to be enabled", async () => {
+    await check(helmet({ crossOriginEmbedderPolicy: true }), {
+      "cross-origin-embedder-policy": "require-corp",
+    });
+  });
+
   it("allows Cross-Origin-Embedder-Policy middleware to be explicitly disabled", async () => {
     await check(helmet({ crossOriginEmbedderPolicy: false }), {
       "cross-origin-embedder-policy": null,


### PR DESCRIPTION
Fixes #302 

Hi @EvanHahn! I'm not sure if we should be checking the `Enabled middlewares with its default` for the following tests since they're being enabled by default already:

- Cross-Origin-Opener-Policy 
https://github.com/helmetjs/helmet/blob/2132648b3a9609fadc2c448377b6976ab0636f1d/test/index.test.ts#L116-L120
- Cross-Origin-Resource-Policy
https://github.com/helmetjs/helmet/blob/2132648b3a9609fadc2c448377b6976ab0636f1d/test/index.test.ts#L139-L143
- Cross-Origin-Embedder-Policy https://github.com/helmetjs/helmet/blob/2132648b3a9609fadc2c448377b6976ab0636f1d/test/index.test.ts#L104-L108
- Oirigin-Agent-Cluster
https://github.com/helmetjs/helmet/blob/2132648b3a9609fadc2c448377b6976ab0636f1d/test/index.test.ts#L160-L164

I'll happily remove them if they're not needed anymore.