### PR TITLE
Add autocomplete to XFrameOptionsOptions

### DIFF
--- a/middlewares/x-frame-options/index.ts
+++ b/middlewares/x-frame-options/index.ts
@@ -1,7 +1,7 @@
 import { IncomingMessage, ServerResponse } from "http";
 
 export interface XFrameOptionsOptions {
-  action?: string;
+  action?: "DENY" | "SAMEORIGIN" | (string & {});
 }
 
 function getHeaderValueFromOptions({


### PR DESCRIPTION
Changes the XFrameOptionsOptions to let typescript suggest "DENY" and
"SAMEORIGIN" in autocomplete with the trick in
microsoft/TypeScript#29729