### PR TITLE
Add frameguard to CSP documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,28 @@ app.use(
     },
   })
 );
+
+// Sets the `frame-ancestors` directive to "'none'"
+// similar to `helmet.frameguard({ action: "deny" })`
+app.use(
+  helmet.contentSecurityPolicy({
+    useDefaults: true,
+    directives: {
+      frameAncestors: ["'none'"],
+    },
+  })
+);
+
+// Sets the `frame-ancestors` directive to "'self'"
+// similar to `helmet.frameguard({ action: "sameorigin" })`
+app.use(
+  helmet.contentSecurityPolicy({
+    useDefaults: true,
+    directives: {
+      frameAncestors: ["'self'"],
+    },
+  })
+);
 ```
 
 You can install this module separately as `helmet-csp`.
@@ -508,7 +530,7 @@ You can install this module separately as `ienoopen`.
 <details>
 <summary><code>helmet.frameguard(options)</code></summary>
 
-`helmet.frameguard` sets the `X-Frame-Options` header to help you mitigate [clickjacking attacks](https://en.wikipedia.org/wiki/Clickjacking). This header is superseded by [the `frame-ancestors` Content Security Policy directive](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-ancestors) but is still useful on old browsers. For more, see [the documentation on MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options).
+`helmet.frameguard` sets the `X-Frame-Options` header to help you mitigate [clickjacking attacks](https://en.wikipedia.org/wiki/Clickjacking). This header is superseded by [the `frame-ancestors` Content Security Policy directive](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-ancestors) but is still useful on old browsers. For more, see `helmet.contentSecurityPolicy`, as well as [the documentation on MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options).
 
 `options.action` is a string that specifies which directive to use—either `DENY` or `SAMEORIGIN`. (A legacy directive, `ALLOW-FROM`, is not supported by this middleware. [Read more here.](https://github.com/helmetjs/helmet/wiki/How-to-use-X%E2%80%93Frame%E2%80%93Options's-%60ALLOW%E2%80%93FROM%60-directive)) It defaults to `SAMEORIGIN`.
 

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ app.use(
 );
 
 // Sets the `frame-ancestors` directive to "'none'"
-// similar to `helmet.frameguard({ action: "deny" })`
+// See also: `helmet.frameguard`
 app.use(
   helmet.contentSecurityPolicy({
     useDefaults: true,

--- a/README.md
+++ b/README.md
@@ -213,8 +213,6 @@ app.use(
     },
   })
 );
-// to get the behavior similar to `helmet.frameguard({ action: "sameorigin" })`
-// replace "'none'" with "'self'"
 ```
 
 You can install this module separately as `helmet-csp`.

--- a/README.md
+++ b/README.md
@@ -213,17 +213,8 @@ app.use(
     },
   })
 );
-
-// Sets the `frame-ancestors` directive to "'self'"
-// similar to `helmet.frameguard({ action: "sameorigin" })`
-app.use(
-  helmet.contentSecurityPolicy({
-    useDefaults: true,
-    directives: {
-      frameAncestors: ["'self'"],
-    },
-  })
-);
+// to get the behavior similar to `helmet.frameguard({ action: "sameorigin" })`
+// replace "'none'" with "'self'"
 ```
 
 You can install this module separately as `helmet-csp`.


### PR DESCRIPTION
Add pointer from `helmet.frameguard` to `helmet.contentSecurityPolicy`.
Add examples in `helmet.contentSecurityPolicy` to mimic `helmet.frameguard`.