### PR TITLE
Updated Code Example

### DIFF
--- a/middlewares/content-security-policy/README.md
+++ b/middlewares/content-security-policy/README.md
@@ -55,6 +55,7 @@ You can dynamically generate nonces to allow inline `<script>` tags to be safely
 
 ```js
 const crypto = require("crypto");
+const contentSecurityPolicy = require("helmet-csp");
 
 app.use((req, res, next) => {
   res.locals.nonce = crypto.randomBytes(16).toString("hex");
@@ -62,7 +63,7 @@ app.use((req, res, next) => {
 });
 
 app.use((req, res, next) => {
-  csp({
+  contentSecurityPolicy({
     useDefaults: true,
     directives: {
       scriptSrc: ["'self'", `'nonce-${res.locals.nonce}'`],


### PR DESCRIPTION
The code example for the Recipe was missing a few things. There was no include for `csp`. I added the include for the contentSecurityPolicy as referenced in the previous example. Also, I made `csp` a little more clear by just expanding it out to be consistent with the first example.

Thanks for all of your hard work. I thought I would contribute a little to make things better for the next folks coming in. Security is a tough thing to get your mind around. Hopefully this helps the next person working on implementing this!