### PR TITLE
Improve CJS/ESM interoperability support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,6 @@
-/.idea/
 /node_modules/
 
 /dist/
-/package/
 /tmp-commonjs-index.ts
 
 /coverage/

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
+/.idea/
 /node_modules/
 
 /dist/
+/package/
 /tmp-commonjs-index.ts
 
 /coverage/

--- a/.npmignore
+++ b/.npmignore
@@ -8,7 +8,7 @@
 !README.md
 !SECURITY.md
 
-!dist/index.cjs
-!dist/index.d.ts
-!dist/index.js
-!dist/middlewares/**/*.d.ts
+!dist/cjs/index.js
+!dist/cjs/package.json
+!dist/esm/index.js
+!dist/types/**/*.d.ts

--- a/bin/build-helmet.js
+++ b/bin/build-helmet.js
@@ -2,36 +2,51 @@
 import * as path from "path";
 import { fileURLToPath } from "url";
 import rollupTypescript from "@rollup/plugin-typescript";
-import { writeRollup, withCommonJsFile } from "./helpers.js";
+import {
+  writeRollup,
+  withCommonJsFile,
+  withEsmFile,
+  renameFile,
+  finalizeCommonJs,
+} from "./helpers.js";
 
 const thisPath = fileURLToPath(import.meta.url);
 const rootPath = path.join(path.dirname(thisPath), "..");
 const esmSourcePath = path.join(rootPath, "index.ts");
-const esmDistPath = path.join(rootPath, "dist", "index.js");
-const commonJsDistPath = path.join(rootPath, "dist", "index.cjs");
+const esmDistDir = path.join(rootPath, "dist", "esm");
+const esmDistPath = path.join(esmDistDir, "index.js");
+const commonJsDistDir = path.join(rootPath, "dist", "cjs");
+const commonJsDistPath = path.join(commonJsDistDir, "index.js");
 
 const compileEsm = () =>
-  writeRollup(
-    {
-      input: esmSourcePath,
-      plugins: [rollupTypescript({ tsconfig: "./tsconfig-esm.json" })],
-    },
-    { file: esmDistPath }
+  withEsmFile(esmSourcePath, (esmTempPath) =>
+    writeRollup(
+      {
+        input: esmTempPath,
+        plugins: [rollupTypescript({ tsconfig: "./tsconfig-esm.json" })],
+      },
+      { file: esmDistPath }
+    ).then(() =>
+      renameFile(
+        path.join(esmDistDir, "tmp-esm-index.d.ts"),
+        path.join(esmDistDir, "index.d.ts")
+      )
+    )
   );
 
 const compileCommonjs = () =>
-  withCommonJsFile(esmSourcePath, (commonJsSourcePath) =>
+  withCommonJsFile(esmSourcePath, (commonJsTempPath) =>
     writeRollup(
       {
-        input: commonJsSourcePath,
+        input: commonJsTempPath,
         plugins: [rollupTypescript({ tsconfig: "./tsconfig-commonjs.json" })],
       },
       {
-        exports: "default",
+        exports: "named",
         file: commonJsDistPath,
         format: "cjs",
       }
-    )
+    ).then(async () => await finalizeCommonJs(commonJsDistDir, esmDistDir))
   );
 
 async function main() {

--- a/bin/build-helmet.js
+++ b/bin/build-helmet.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { promises as fs } from "fs";
 import * as path from "path";
 import { fileURLToPath } from "url";
 import rollupTypescript from "@rollup/plugin-typescript";
@@ -8,15 +9,18 @@ import {
   withEsmFile,
   renameFile,
   finalizeCommonJs,
+  moveDir
 } from "./helpers.js";
 
 const thisPath = fileURLToPath(import.meta.url);
 const rootPath = path.join(path.dirname(thisPath), "..");
+const distPath = path.join(rootPath, "dist");
 const esmSourcePath = path.join(rootPath, "index.ts");
-const esmDistDir = path.join(rootPath, "dist", "esm");
+const esmDistDir = path.join(distPath, "esm");
 const esmDistPath = path.join(esmDistDir, "index.js");
-const commonJsDistDir = path.join(rootPath, "dist", "cjs");
+const commonJsDistDir = path.join(distPath, "cjs");
 const commonJsDistPath = path.join(commonJsDistDir, "index.js");
+const typesDistDir = path.join(distPath, "types");
 
 const compileEsm = () =>
   withEsmFile(esmSourcePath, (esmTempPath) =>
@@ -26,11 +30,6 @@ const compileEsm = () =>
         plugins: [rollupTypescript({ tsconfig: "./tsconfig-esm.json" })],
       },
       { file: esmDistPath }
-    ).then(() =>
-      renameFile(
-        path.join(esmDistDir, "tmp-esm-index.d.ts"),
-        path.join(esmDistDir, "index.d.ts")
-      )
     )
   );
 
@@ -49,9 +48,21 @@ const compileCommonjs = () =>
     ).then(async () => await finalizeCommonJs(commonJsDistDir, esmDistDir))
   );
 
+const finalizeTypes = async () => {
+  await fs.mkdir(typesDistDir);
+  await fs.mkdir(path.join(typesDistDir, "middlewares"));
+  await renameFile(
+    path.join(esmDistDir, "tmp-esm-index.d.ts"),
+    path.join(distPath, "types", "index.d.ts")
+  );
+  await moveDir(path.join(esmDistDir, "middlewares"), path.join(typesDistDir, "middlewares"))
+  await fs.rmdir(path.join(esmDistDir, "middlewares"));
+}
+
 async function main() {
   await compileEsm();
   await compileCommonjs();
+  await finalizeTypes();
 }
 
 main(process.argv).catch((err) => {

--- a/bin/helpers.js
+++ b/bin/helpers.js
@@ -47,7 +47,7 @@ export async function withCommonJsFile(esmSourcePath, fn) {
     line.includes("!helmet-end-of-commonjs-exports")
   );
   lines.splice(startLine, 1);
-  const resultLines = lines.slice(0, endLine);
+  const resultLines = lines.slice(0, endLine - 1);
 
   try {
     await fs.writeFile(commonJsTempPath, resultLines.join("\n"));
@@ -55,37 +55,5 @@ export async function withCommonJsFile(esmSourcePath, fn) {
     await fn(commonJsTempPath);
   } finally {
     await fs.unlink(commonJsTempPath);
-  }
-}
-
-export async function renameFile(oldPath, newPath) {
-  await fs.rename(oldPath, newPath)
-    .catch((error) => {
-      if (error) console.error(error);
-    });
-}
-
-export async function finalizeCommonJs(commonJsDistDir) {
-  const cjsPackageJson = JSON.stringify({
-    type: "commonjs",
-  });
-
-  await fs.writeFile(
-    path.join(commonJsDistDir, "package.json"),
-    cjsPackageJson
-  );
-}
-
-export async function moveDir(oldPath, newPath) {
-  await fs.mkdir(newPath, { recursive: true });
-  let entries = await fs.readdir(oldPath, { withFileTypes: true });
-
-  for (let entry of entries) {
-    let srcPath = path.join(oldPath, entry.name);
-    let destPath = path.join(newPath, entry.name);
-
-    entry.isDirectory() ?
-      (await moveDir(srcPath, destPath), await fs.rmdir(srcPath)) :
-      (await fs.copyFile(srcPath, destPath), await fs.rm(srcPath));
   }
 }

--- a/bin/helpers.js
+++ b/bin/helpers.js
@@ -8,23 +8,74 @@ export async function writeRollup(inputOptions, outputOptions) {
   await bundle.close();
 }
 
+export async function withEsmFile(esmSourcePath, fn) {
+  const esmTempPath = path.join(
+    path.dirname(esmSourcePath),
+    "tmp-esm-index.ts"
+  );
+
+  const lines = (await fs.readFile(esmSourcePath, "utf8")).split(/\r?\n/);
+  const startLine = lines.findIndex((line) =>
+    line.includes("!helmet-start-of-commonjs-exports")
+  );
+  const endLine = lines.findIndex((line) =>
+    line.includes("!helmet-end-of-commonjs-exports")
+  );
+  const lineCount = endLine - startLine + 1;
+  lines.splice(startLine, lineCount);
+
+  try {
+    await fs.writeFile(esmTempPath, lines.join("\n"));
+
+    await fn(esmTempPath);
+  } finally {
+    await fs.unlink(esmTempPath);
+  }
+}
+
 export async function withCommonJsFile(esmSourcePath, fn) {
-  const commonJsSourcePath = path.join(
+  const commonJsTempPath = path.join(
     path.dirname(esmSourcePath),
     "tmp-commonjs-index.ts"
   );
 
   const lines = (await fs.readFile(esmSourcePath, "utf8")).split(/\r?\n/);
-  const resultLines = lines.slice(
-    0,
-    lines.findIndex((line) => line.includes("!helmet-end-of-commonjs"))
+  const startLine = lines.findIndex((line) =>
+    line.includes("!helmet-start-of-commonjs-exports")
   );
+  const endLine = lines.findIndex((line) =>
+    line.includes("!helmet-end-of-commonjs-exports")
+  );
+  lines.splice(startLine, 1);
+  const resultLines = lines.slice(0, endLine);
 
   try {
-    await fs.writeFile(commonJsSourcePath, resultLines.join("\n"));
+    await fs.writeFile(commonJsTempPath, resultLines.join("\n"));
 
-    await fn(commonJsSourcePath);
+    await fn(commonJsTempPath);
   } finally {
-    await fs.unlink(commonJsSourcePath);
+    await fs.unlink(commonJsTempPath);
   }
+}
+
+export function renameFile(oldPath, newPath) {
+  fs.rename(oldPath, newPath),
+    (error) => {
+      if (error) console.error(error);
+    };
+}
+
+export async function finalizeCommonJs(commonJsDistDir, esmDistDir) {
+  const cjsPackageJson = JSON.stringify({
+    type: "commonjs",
+  });
+
+  await fs.writeFile(
+    path.join(commonJsDistDir, "package.json"),
+    cjsPackageJson
+  );
+  await fs.copyFile(
+    path.join(esmDistDir, "index.d.ts"),
+    path.join(commonJsDistDir, "index.d.ts")
+  );
 }

--- a/bin/helpers.js
+++ b/bin/helpers.js
@@ -15,14 +15,24 @@ export async function withEsmFile(esmSourcePath, fn) {
   );
 
   const lines = (await fs.readFile(esmSourcePath, "utf8")).split(/\r?\n/);
-  const startLine = lines.findIndex((line) =>
+  const startLineCjsFence = lines.findIndex((line) =>
     line.includes("!helmet-start-of-commonjs-exports")
   );
-  const endLine = lines.findIndex((line) =>
+  const endLineCjsFence = lines.findIndex((line) =>
     line.includes("!helmet-end-of-commonjs-exports")
   );
-  const lineCount = endLine - startLine + 1;
-  lines.splice(startLine, lineCount);
+  const lineCount = endLineCjsFence - startLineCjsFence + 2;
+  lines.splice(startLineCjsFence, lineCount);
+
+  const startLineEsmFence = lines.findIndex((line) =>
+    line.includes("!helmet-start-of-esm-exports")
+  );
+  lines.splice(startLineEsmFence, 1);
+
+  const endLineEsmFence = lines.findIndex((line) =>
+    line.includes("!helmet-end-of-esm-exports")
+  );
+  lines.splice(endLineEsmFence, 1);
 
   try {
     await fs.writeFile(esmTempPath, lines.join("\n"));

--- a/index.ts
+++ b/index.ts
@@ -278,6 +278,7 @@ exports = helmet;
 module.exports = helmet;
 // !helmet-end-of-commonjs-exports
 
+// !helmet-start-of-esm-exports
 export {
   contentSecurityPolicy,
   crossOriginEmbedderPolicy,
@@ -295,3 +296,4 @@ export {
   xPoweredBy as hidePoweredBy,
   xXssProtection as xssFilter,
 };
+// !helmet-end-of-esm-exports

--- a/index.ts
+++ b/index.ts
@@ -273,7 +273,10 @@ const helmet: Helmet = Object.assign(
 
 export default helmet;
 
-// !helmet-end-of-commonjs
+// !helmet-start-of-commonjs-exports
+exports = helmet;
+module.exports = helmet;
+// !helmet-end-of-commonjs-exports
 
 export {
   contentSecurityPolicy,

--- a/package.json
+++ b/package.json
@@ -54,13 +54,15 @@
   },
   "license": "MIT",
   "type": "module",
-  "types": "./dist/index.d.ts",
-  "main": "./dist/index.cjs",
+  "main": "./dist/cjs/index.js",
+  "module": "./dist/esm/index.js",
   "exports": {
     ".": {
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs",
-      "types": "./dist/index.d.ts"
+      "import": "./dist/esm/index.js",
+      "require": "./dist/cjs/index.js"
     }
-  }
+  },
+  "files": [
+    "dist"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -56,10 +56,12 @@
   "type": "module",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
+  "types": "./dist/types/index.d.ts",
   "exports": {
     ".": {
       "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.js"
+      "require": "./dist/cjs/index.js",
+      "types": "./dist/types/index.d.ts"
     }
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -63,8 +63,5 @@
       "require": "./dist/cjs/index.js",
       "types": "./dist/types/index.d.ts"
     }
-  },
-  "files": [
-    "dist"
-  ]
+  }
 }

--- a/tsconfig-esm.json
+++ b/tsconfig-esm.json
@@ -1,9 +1,8 @@
 {
   "extends": "./tsconfig",
-  "exclude": ["dist"],
   "compilerOptions": {
-    "outDir": "dist",
     "declaration": true,
     "declarationDir": "."
-  }
+  },
+  "include": ["tmp-esm-index.ts"]
 }

--- a/tsconfig-esm.json
+++ b/tsconfig-esm.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig",
   "compilerOptions": {
     "declaration": true,
-    "declarationDir": "."
+    "declarationDir": "types"
   },
   "include": ["tmp-esm-index.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,8 @@
     "noUnusedParameters": true,
     "noUncheckedIndexedAccess": true,
     "strict": true,
-    "target": "es6"
-  }
+    "target": "es6",
+    "outDir": "."
+  },
+  "exclude": ["node_modules", "bin", "dist"]
 }


### PR DESCRIPTION
Resolves #344 (hopefully).

The real main difference here is we have some additional CJS exports in `index.ts`, but these exports aren't compatible with ESM so have to be removed in the `build-helmet.js` process.

I made a local package with `npm run build-helmet && npm pack` and went through the few test cases in https://github.com/helmetjs/helmet/blob/main/MAINTAINER_README.md and all seemed to pass. It also resolved my issue detailed in the above issue thread without changing my `tsconfig.json` or the way I import `helmet`. Which on top of fixing the issue also means there is no longer anything breaking changed for me from `v4` to `v5`.

I welcome any feedback and if it helps any of the other people in the above thread.