### PR TITLE
types: rename `XFrameOptionsOptions` to `XFrameOptions`

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -23,6 +23,7 @@ import xDnsPrefetchControl, {
 } from "./middlewares/x-dns-prefetch-control";
 import xDownloadOptions from "./middlewares/x-download-options";
 import xFrameOptions, {
+  XFrameOptions,
   XFrameOptionsOptions,
 } from "./middlewares/x-frame-options";
 import xPermittedCrossDomainPolicies, {
@@ -38,7 +39,7 @@ export interface HelmetOptions {
   crossOriginResourcePolicy?: CrossOriginResourcePolicyOptions | boolean;
   dnsPrefetchControl?: XDnsPrefetchControlOptions | boolean;
   expectCt?: ExpectCtOptions | boolean;
-  frameguard?: XFrameOptionsOptions | boolean;
+  frameguard?: XFrameOptions | XFrameOptionsOptions | boolean;
   hidePoweredBy?: boolean;
   hsts?: StrictTransportSecurityOptions | boolean;
   ieNoOpen?: boolean;

--- a/middlewares/x-frame-options/index.ts
+++ b/middlewares/x-frame-options/index.ts
@@ -1,13 +1,18 @@
 import { IncomingMessage, ServerResponse } from "http";
 
-export interface XFrameOptionsOptions {
+export interface XFrameOptions {
   // This offers autocomplete while still supporting regular `string`s.
   action?: "DENY" | "SAMEORIGIN" | (string & { _?: never });
 }
 
+/**
+ * @deprecated Use `XFrameOptions` instead
+ */
+export interface XFrameOptionsOptions extends XFrameOptions {}
+
 function getHeaderValueFromOptions({
   action = "SAMEORIGIN",
-}: Readonly<XFrameOptionsOptions>): string {
+}: Readonly<XFrameOptions>): string {
   const normalizedAction =
     typeof action === "string" ? action.toUpperCase() : action;
 
@@ -28,7 +33,7 @@ function getHeaderValueFromOptions({
   }
 }
 
-function xFrameOptions(options: Readonly<XFrameOptionsOptions> = {}) {
+function xFrameOptions(options: Readonly<XFrameOptions> = {}) {
   const headerValue = getHeaderValueFromOptions(options);
 
   return function xFrameOptionsMiddleware(


### PR DESCRIPTION
Hello.

This PR aims to :
- rename `frameguard` middleware typescript definition `XFrameOptionsOptions` to `XFrameOptions`
- deprecate typescript definition `XFrameOptionsOptions` in favor of `XFrameOptions` to avoid any breaking change for typescript users

No breaking change is introduced by this PR. ^^