### PR TITLE
Clarify README grammar slightly

### DIFF
--- a/README.md
+++ b/README.md
@@ -586,7 +586,7 @@ You can install this module separately as `helmet-crossdomain`.
 
 This middleware takes no options.
 
-If you're using Express, this middleware will work, but you should use `app.disable("x-powered-by")` instead.
+If you're using Express, this middleware will work, but otherwise, you should use `app.disable("x-powered-by")`.
 
 Examples:
 


### PR DESCRIPTION
This is a tiny change to adjust the wording from "instead" to "otherwise". I believe this is congruent with the intended meaning of the sentence, but if not, clarification would be appreciated. As a native US English speaker, this sentence confused me for at least a few minutes.

Slightly more technically, the combination of "but" and "instead" here implies (to me) that the preceding clause ("this middleware will work") is unconditionally negated by "you should use `app.disable("x-powered-by")`".  It implies that you should **always** prefer using `app.disable("x-powered-by")` _instead_ of this middleware.

I chose not to in the PR, but it could also be written more simply as "If you're not using Express, you should use `app.disable("x-powered-by")`." It's previously documented that Helmet is a tool for Express, so the reader already knows this middleware works for Express.
