### PR TITLE
COEP: Add support for credentialless policy

### DIFF
--- a/middlewares/cross-origin-embedder-policy/index.ts
+++ b/middlewares/cross-origin-embedder-policy/index.ts
@@ -1,12 +1,36 @@
 import { IncomingMessage, ServerResponse } from "http";
 
-function crossOriginEmbedderPolicy() {
+export interface CrossOriginEmbedderPolicyOptions {
+  policy?: string;
+}
+
+const ALLOWED_POLICIES = new Set(["require-corp", "credentialless"]);
+
+function getHeaderValueFromOptions({
+  policy = "require-corp",
+}: Readonly<CrossOriginEmbedderPolicyOptions>): string {
+  if (ALLOWED_POLICIES.has(policy)) {
+    return policy;
+  } else {
+    throw new Error(
+      `Cross-Origin-Embedder-Policy does not support the ${JSON.stringify(
+        policy
+      )} policy`
+    );
+  }
+}
+
+function crossOriginEmbedderPolicy(
+  options: Readonly<CrossOriginEmbedderPolicyOptions> = {}
+) {
+  const headerValue = getHeaderValueFromOptions(options);
+
   return function crossOriginEmbedderPolicyMiddleware(
     _req: IncomingMessage,
     res: ServerResponse,
     next: () => void
-  ): void {
-    res.setHeader("Cross-Origin-Embedder-Policy", "require-corp");
+  ) {
+    res.setHeader("Cross-Origin-Embedder-Policy", headerValue);
     next();
   };
 }

--- a/test/cross-origin-embedder-policy.test.ts
+++ b/test/cross-origin-embedder-policy.test.ts
@@ -2,9 +2,43 @@ import { check } from "./helpers";
 import crossOriginEmbedderPolicy from "../middlewares/cross-origin-embedder-policy";
 
 describe("Cross-Origin-Embedder-Policy middleware", () => {
-  it('sets "Cross-Origin-Embedder-Policy: require-corp"', async () => {
-    await check(crossOriginEmbedderPolicy(), {
+  it('sets "Cross-Origin-Embedder-Policy: same-origin" when called with no policy', async () => {
+    const expectedHeaders = {
       "cross-origin-embedder-policy": "require-corp",
+    };
+    await check(crossOriginEmbedderPolicy(), expectedHeaders);
+    await check(crossOriginEmbedderPolicy({}), expectedHeaders);
+    await check(
+      crossOriginEmbedderPolicy(Object.create(null)),
+      expectedHeaders
+    );
+    await check(
+      crossOriginEmbedderPolicy({ policy: undefined }),
+      expectedHeaders
+    );
+  });
+
+  ["require-corp", "credentialless"].forEach((policy) => {
+    it(`sets "Cross-Origin-Embedder-Policy: ${policy}" when told to`, async () => {
+      await check(crossOriginEmbedderPolicy({ policy }), {
+        "cross-origin-embedder-policy": policy,
+      });
     });
+  });
+
+  it("throws when setting the policy to an invalid value", () => {
+    const invalidValues = [
+      "",
+      "NONE",
+      "by-ftp-filename",
+      123 as any,
+      null as any,
+      new String("none") as any,
+    ];
+    for (const policy of invalidValues) {
+      expect(() => crossOriginEmbedderPolicy({ policy })).toThrow(
+        /^Cross-Origin-Embedder-Policy does not support /
+      );
+    }
   });
 });


### PR DESCRIPTION
Per [mozilla docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Embedder-Policy) and [chrome docs](https://developer.chrome.com/blog/coep-credentialless-origin-trial/#credentialless-to-the-rescue), Cross-Origin-Embedder-Policy supports an experimental policy mode of `credentialless`. This PR enables the option to use it.