### PR TITLE
ci: update github actions

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -3,7 +3,7 @@ name: Node.js CI
 on: [push]
 
 permissions:
-    contents: read
+  contents: read
 
 jobs:
   build:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -2,6 +2,9 @@ name: Node.js CI
 
 on: [push]
 
+permissions:
+    contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -11,8 +14,10 @@ jobs:
         node-version: [12.x, 14.x, 16.x]
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm ci


### PR DESCRIPTION
This PR:

-   Bumps GitHub Actions to their latest major versions, which now use Node 16 internally instead of Node 12 (EOL, no longer receives security updates):
    -   Changelog for `actions/checkout` can be [found here](https://github.com/actions/checkout/blob/main/CHANGELOG.md)
    -   Releases for `actions/setup-node` can be [found here](https://github.com/actions/setup-node/releases)
-   Declares the minimum permissions for CI workflows to run at the workflow level, following principle of least privilege; see [related GitHub security post](https://securitylab.github.com/research/github-actions-building-blocks/)
-   Removes Git credentials/SSH keys after checkout as a security precaution by setting `persist-credentials` to false, they are not used after the initial checkout
