### PR TITLE
Remove block-all-mixed-content directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,6 @@ These directives are merged into a default policy, which you can disable by sett
 
     default-src 'self';
     base-uri 'self';
-    block-all-mixed-content;
     font-src 'self' https: data:;
     form-action 'self';
     frame-ancestors 'self';

--- a/middlewares/content-security-policy/README.md
+++ b/middlewares/content-security-policy/README.md
@@ -29,7 +29,6 @@ If no directives are supplied, the following policy is set (whitespace added for
 
     default-src 'self';
     base-uri 'self';
-    block-all-mixed-content;
     font-src 'self' https: data:;
     form-action 'self';
     frame-ancestors 'self';

--- a/middlewares/content-security-policy/index.ts
+++ b/middlewares/content-security-policy/index.ts
@@ -42,7 +42,6 @@ const DEFAULT_DIRECTIVES: Record<
 > = {
   "default-src": ["'self'"],
   "base-uri": ["'self'"],
-  "block-all-mixed-content": [],
   "font-src": ["'self'", "https:", "data:"],
   "form-action": ["'self'"],
   "frame-ancestors": ["'self'"],

--- a/test/content-security-policy.test.ts
+++ b/test/content-security-policy.test.ts
@@ -31,7 +31,6 @@ describe("Content-Security-Policy middleware", () => {
     const expectedDirectives = new Set([
       "default-src 'self'",
       "base-uri 'self'",
-      "block-all-mixed-content",
       "font-src 'self' https: data:",
       "form-action 'self'",
       "frame-ancestors 'self'",
@@ -225,7 +224,6 @@ describe("Content-Security-Policy middleware", () => {
   it("can override the default options", async () => {
     const expectedDirectives = new Set([
       "default-src 'self' example.com",
-      "block-all-mixed-content",
       "font-src 'self' https: data:",
       "form-action 'self'",
       "frame-ancestors 'self'",
@@ -481,7 +479,6 @@ describe("Content-Security-Policy middleware", () => {
       ],
       expectedDirectives: new Set([
         "base-uri 'self'",
-        "block-all-mixed-content",
         "font-src 'self' https: data:",
         "form-action 'self'",
         "frame-ancestors 'self'",
@@ -537,7 +534,6 @@ describe("getDefaultDirectives", () => {
   it("returns the middleware's default directives", () => {
     expect(getDefaultDirectives()).toEqual({
       "base-uri": ["'self'"],
-      "block-all-mixed-content": [],
       "default-src": ["'self'"],
       "font-src": ["'self'", "https:", "data:"],
       "form-action": ["'self'"],

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -30,7 +30,7 @@ describe("helmet", () => {
     // we should update this test to be more robust.
     const expectedHeaders = {
       "content-security-policy":
-        "default-src 'self';base-uri 'self';block-all-mixed-content;font-src 'self' https: data:;form-action 'self';frame-ancestors 'self';img-src 'self' data:;object-src 'none';script-src 'self';script-src-attr 'none';style-src 'self' https: 'unsafe-inline';upgrade-insecure-requests",
+        "default-src 'self';base-uri 'self';font-src 'self' https: data:;form-action 'self';frame-ancestors 'self';img-src 'self' data:;object-src 'none';script-src 'self';script-src-attr 'none';style-src 'self' https: 'unsafe-inline';upgrade-insecure-requests",
       "cross-origin-embedder-policy": "require-corp",
       "cross-origin-opener-policy": "same-origin",
       "cross-origin-resource-policy": "same-origin",


### PR DESCRIPTION
The block-all-mixed-content directive is deprecated and not recommended 

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/block-all-mixed-content