### PR TITLE
fix cjs with nodenext interop issue

### DIFF
--- a/.github/workflows/typescript-interop.yml
+++ b/.github/workflows/typescript-interop.yml
@@ -23,6 +23,8 @@ jobs:
           - Node
           - Node16
           - Nodenext
+      fail-fast: false
+
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/typescript-interop.yml
+++ b/.github/workflows/typescript-interop.yml
@@ -1,4 +1,4 @@
-name: Node.js CI
+name: Typescript Interop
 
 on: [push]
 
@@ -6,7 +6,7 @@ permissions:
   contents: read
 
 jobs:
-  build:
+  interop-test:
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/typescript-interop.yml
+++ b/.github/workflows/typescript-interop.yml
@@ -23,8 +23,20 @@ jobs:
           - Node
           - Node16
           - Nodenext
-      fail-fast: false
+        exclude:
+          - package-json-type: commonjs
+            tsconfig-json-module: ESNext
+          - package-json-type: module
+            tsconfig-json-module: CommonJS
+          - package-json-type: module
+            tsconfig-json-module: Node16
+            tsconfig-json-module-resolution: Node
+          - package-json-type: module
+            tsconfig-json-module: NodeNext
+            tsconfig-json-module-resolution: Node
 
+      fail-fast: false
+   
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/typescript-interop.yml
+++ b/.github/workflows/typescript-interop.yml
@@ -1,0 +1,45 @@
+name: Node.js CI
+
+on: [push]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        package-json-type:
+          - commonjs
+          - module
+        tsconfig-json-module:
+          - CommonJS
+          - ESNext
+          - Node16
+          - Nodenext
+        tsconfig-json-module-resolution:
+          - Node
+          - Node16
+          - Nodenext
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: |
+          npm ci &&
+          npm run build-helmet &&
+          npm link &&
+          node bin/create-interop-test &&
+          cd test_interop &&
+          npm i &&
+          npm link helmet &&
+          npm run test-interop
+        env:
+          PACKAGE_JSON_TYPE: ${{ matrix.package-json-type }}
+          TSCONFIG_MODULE: ${{ matrix.tsconfig-json-module }}
+          TSCONFIG_MODULE_RESOLUTION: ${{ matrix.tsconfig-json-module-resolution }}

--- a/.github/workflows/typescript-interop.yml
+++ b/.github/workflows/typescript-interop.yml
@@ -36,7 +36,7 @@ jobs:
             tsconfig-json-module-resolution: Node
 
       fail-fast: false
-   
+
     steps:
       - uses: actions/checkout@v3
         with:

--- a/bin/build-helmet.js
+++ b/bin/build-helmet.js
@@ -25,11 +25,10 @@ const compileEsm = () =>
       { file: path.join(distPath, "index.js") }
     );
 
-    await fs.mkdir(esmDistDir);
     await fs.rename(path.join(distPath, "index.js"), esmDistPath);
     await fs.rename(
-      path.join(typesDistDir, "tmp-esm-index.d.ts"),
-      path.join(typesDistDir, "index.d.ts")
+      path.join(esmDistDir, "tmp-esm-index.d.ts"),
+      path.join(esmDistDir, "index.d.ts")
     );
   });
 
@@ -54,6 +53,10 @@ const compileCommonjs = () =>
     await fs.writeFile(
       path.join(commonJsDistDir, "package.json"),
       cjsPackageJson
+    );
+    await fs.rename(
+      path.join(commonJsDistDir, "tmp-commonjs-index.d.ts"),
+      path.join(commonJsDistDir, "index.d.ts")
     );
   });
 

--- a/bin/build-helmet.js
+++ b/bin/build-helmet.js
@@ -53,6 +53,7 @@ const compileCommonjs = () =>
       path.join(commonJsDistDir, "package.json"),
       cjsPackageJson
     );
+
     await fs.rename(
       path.join(commonJsDistDir, "tmp-commonjs-index.d.ts"),
       path.join(commonJsDistDir, "index.d.ts")

--- a/bin/build-helmet.js
+++ b/bin/build-helmet.js
@@ -13,7 +13,6 @@ const esmDistDir = path.join(distPath, "esm");
 const esmDistPath = path.join(esmDistDir, "index.js");
 const commonJsDistDir = path.join(distPath, "cjs");
 const commonJsDistPath = path.join(commonJsDistDir, "index.js");
-const typesDistDir = path.join(distPath, "types");
 
 const compileEsm = () =>
   withEsmFile(esmSourcePath, async (esmTempPath) => {

--- a/bin/create-interop-test.js
+++ b/bin/create-interop-test.js
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+import * as path from "path";
+import { promises as fs } from "fs";
+import { fileURLToPath } from "url";
+
+const packageJsonType = process.argv[2] || process.env.PACKAGE_JSON_TYPE || 'commonjs'
+const tsconfigModule = process.argv[2] || process.env.TSCONFIG_MODULE || 'Node'
+const tsconfigModuleResolution = process.argv[2] || process.env.TSCONFIG_MODULE_RESOLUTION ||'Node'
+
+const thisPath = fileURLToPath(import.meta.url);
+const rootPath = path.join(path.dirname(thisPath), "..");
+const testPath = path.join(rootPath, 'test_interop');
+
+const indexTs = `import helmet from 'helmet'
+import { equal } from "assert"
+
+equal(typeof helmet, 'function')`
+
+const tsconfigJson = JSON.stringify({
+  "compilerOptions": {
+    "module": tsconfigModule,
+    "moduleResolution": tsconfigModuleResolution
+  }
+}, null, 2)
+
+const packageJson = JSON.stringify({
+  "name": "helmet-test",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "type": packageJsonType,
+  "scripts": {
+    "test-interop": "tsc -p . && node index.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@types/node": "^18.11.10",
+    "typescript": "^4.9.3"
+  }
+}, null, 2)
+
+async function main() {
+  await fs.mkdir(testPath)
+  await fs.writeFile(path.join(testPath, "package.json"), packageJson);
+  await fs.writeFile(path.join(testPath, "tsconfig.json"), tsconfigJson);
+  await fs.writeFile(path.join(testPath, "index.ts"), indexTs);
+}
+
+main(process.argv).catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/bin/create-interop-test.js
+++ b/bin/create-interop-test.js
@@ -3,46 +3,56 @@ import * as path from "path";
 import { promises as fs } from "fs";
 import { fileURLToPath } from "url";
 
-const packageJsonType = process.argv[2] || process.env.PACKAGE_JSON_TYPE || 'commonjs'
-const tsconfigModule = process.argv[2] || process.env.TSCONFIG_MODULE || 'Node'
-const tsconfigModuleResolution = process.argv[2] || process.env.TSCONFIG_MODULE_RESOLUTION ||'Node'
+const packageJsonType =
+  process.argv[2] || process.env.PACKAGE_JSON_TYPE || "commonjs";
+const tsconfigModule = process.argv[2] || process.env.TSCONFIG_MODULE || "Node";
+const tsconfigModuleResolution =
+  process.argv[2] || process.env.TSCONFIG_MODULE_RESOLUTION || "Node";
 
 const thisPath = fileURLToPath(import.meta.url);
 const rootPath = path.join(path.dirname(thisPath), "..");
-const testPath = path.join(rootPath, 'test_interop');
+const testPath = path.join(rootPath, "test_interop");
 
 const indexTs = `import helmet from 'helmet'
 import { equal } from "assert"
 
-equal(typeof helmet, 'function')`
+equal(typeof helmet, 'function')`;
 
-const tsconfigJson = JSON.stringify({
-  "compilerOptions": {
-    "module": tsconfigModule,
-    "moduleResolution": tsconfigModuleResolution
-  }
-}, null, 2)
-
-const packageJson = JSON.stringify({
-  "name": "helmet-test",
-  "version": "1.0.0",
-  "description": "",
-  "main": "index.js",
-  "type": packageJsonType,
-  "scripts": {
-    "test-interop": "tsc -p . && node index.js"
+const tsconfigJson = JSON.stringify(
+  {
+    compilerOptions: {
+      module: tsconfigModule,
+      moduleResolution: tsconfigModuleResolution,
+    },
   },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
-  "dependencies": {
-    "@types/node": "^18.11.10",
-    "typescript": "^4.9.3"
-  }
-}, null, 2)
+  null,
+  2
+);
+
+const packageJson = JSON.stringify(
+  {
+    name: "helmet-test",
+    version: "1.0.0",
+    description: "",
+    main: "index.js",
+    type: packageJsonType,
+    scripts: {
+      "test-interop": "tsc -p . && node index.js",
+    },
+    keywords: [],
+    author: "",
+    license: "ISC",
+    dependencies: {
+      "@types/node": "^18.11.10",
+      typescript: "^4.9.3",
+    },
+  },
+  null,
+  2
+);
 
 async function main() {
-  await fs.mkdir(testPath)
+  await fs.mkdir(testPath);
   await fs.writeFile(path.join(testPath, "package.json"), packageJson);
   await fs.writeFile(path.join(testPath, "tsconfig.json"), tsconfigJson);
   await fs.writeFile(path.join(testPath, "index.ts"), indexTs);

--- a/package.json
+++ b/package.json
@@ -60,9 +60,9 @@
   "types": "./dist/esm/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/esm/index.d.ts",
+      "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js",
-      "import": "./dist/esm/index.js"
+      "types": "./dist/esm/index.d.ts"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -60,9 +60,9 @@
   "types": "./dist/esm/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/esm/index.d.ts",
       "require": "./dist/cjs/index.js",
-      "import": "./dist/esm/index.js",
-      "types": "./dist/esm/index.d.ts"
+      "import": "./dist/esm/index.js"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -60,9 +60,9 @@
   "types": "./dist/esm/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/esm/index.d.ts",
       "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.js",
-      "types": "./dist/esm/index.d.ts"
+      "require": "./dist/cjs/index.js"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   "type": "module",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
-  "types": "./dist/esm/index.d.ts",
+  "types": "./dist/cjs/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/esm/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -60,8 +60,8 @@
   "types": "./dist/esm/index.d.ts",
   "exports": {
     ".": {
-      "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js",
+      "import": "./dist/esm/index.js",
       "types": "./dist/esm/index.d.ts"
     }
   }

--- a/package.json
+++ b/package.json
@@ -57,12 +57,12 @@
   "type": "module",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
-  "types": "./dist/types/index.d.ts",
+  "types": "./dist/esm/index.d.ts",
   "exports": {
     ".": {
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js",
-      "types": "./dist/types/index.d.ts"
+      "types": "./dist/esm/index.d.ts"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -57,12 +57,12 @@
   "type": "module",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./dist/esm/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/esm/index.d.ts",
       "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.js"
+      "require": "./dist/cjs/index.js",
+      "types": "./dist/esm/index.d.ts"
     }
   }
 }

--- a/tsconfig-commonjs.json
+++ b/tsconfig-commonjs.json
@@ -1,4 +1,7 @@
 {
   "extends": "./tsconfig",
+  "compilerOptions": {
+    "declaration": true
+  },
   "include": ["tmp-commonjs-index.ts"]
 }

--- a/tsconfig-esm.json
+++ b/tsconfig-esm.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig",
   "compilerOptions": {
     "declaration": true,
-    "declarationDir": "types"
+    "declarationDir": "esm"
   },
   "include": ["tmp-esm-index.ts"]
 }


### PR DESCRIPTION
Resolves #389 

I tried to keep a centralized types-folder in dist, but unfortunately but after 2h of trial and error, this was the most straight forward way to fix the issue. Now we have typings next to the index.js for esm and cjs and it works.