### PR TITLE
Remove 'scripts' and 'devDependencies' from published packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "scripts": {
     "pretest": "npm run lint",
-    "prepublishOnly": "npm run build-helmet",
+    "prepublishOnly": "npm run build-helmet && npm pkg delete devDependencies scripts",
     "lint": "npm run lint:eslint && npm run lint:prettier",
     "lint:eslint": "eslint .",
     "lint:prettier": "prettier --check .",


### PR DESCRIPTION
First, I want to thank the Helmet team for making Express applications more secure! This PR is for #384, and aims to reduce the size of `package.json` in published packages. After running the updated `prepublishOnly` script, this PR should cut out the `devDependencies` and `scripts` sections, and reduce the `package.json` size from about 2071 to 992 bytes (according to the `wc --bytes package.json` Linux command). Please let me know if you would like me to make any changes, and thank you for the opportunity to contribute!