### PR TITLE
Remove helmet.expectCt() from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,6 @@ app.use(helmet.crossOriginEmbedderPolicy());
 app.use(helmet.crossOriginOpenerPolicy());
 app.use(helmet.crossOriginResourcePolicy());
 app.use(helmet.dnsPrefetchControl());
-app.use(helmet.expectCt());
 app.use(helmet.frameguard());
 app.use(helmet.hidePoweredBy());
 app.use(helmet.hsts());


### PR DESCRIPTION
It is not set by default anymore since Helmet 6.0.0.

Fixes #397 