### PR TITLE
DOCS: Add README and CHANGELOG for cross-origin-* middlewares

### DIFF
--- a/middlewares/cross-origin-embedder-policy/CHANGELOG.md
+++ b/middlewares/cross-origin-embedder-policy/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+### Commited 04/17/2021 by @EvanHahn
+
+### Updated 05/16/2022 by @Twipped to support new "credentialless" policy.
+
+### Added CHANGELOG.md and README.md

--- a/middlewares/cross-origin-embedder-policy/README.md
+++ b/middlewares/cross-origin-embedder-policy/README.md
@@ -1,0 +1,15 @@
+# Cross-Origin-Embedder-Policy middleware
+
+This middleware sets the `Cross-Origin-Embedder-Policy header`. It is used to control whether a document is allowed to use resources that require a same-origin embedding mechanism. This is a security feature that prevents cross-origin information leaks. Read more about it [here](https://http.dev/cross-origin-embedder-policy).
+
+Usage:
+
+```javascript
+const crossOriginEmbedderPolicy = require("cross-origin-embedder-policy");
+
+// Sets "Cross-Origin-Embedder-Policy: require-corp" (default)
+app.use(crossOriginEmbedderPolicy());
+
+// Sets "Cross-Origin-Embedder-Policy: credentialless" (experimental policy)
+app.use(crossOriginEmbedderPolicy({ policy: "credentialless" }));
+```

--- a/middlewares/cross-origin-opener-policy/CHANGELOG.md
+++ b/middlewares/cross-origin-opener-policy/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+### Commited 04/17/2021 by @EvanHahn
+
+### Added CHANGELOG.md and README.md

--- a/middlewares/cross-origin-opener-policy/README.md
+++ b/middlewares/cross-origin-opener-policy/README.md
@@ -1,0 +1,18 @@
+# Cross-Origin-Opener-Policy middleware
+
+This middleware sets the `Cross-Origin-Opener-Policy` header. It is used to control whether a document is allowed to use features that require a same-origin opener. This is a security feature that prevents cross-origin information leaks. Read more about it [here](https://web.dev/coop-coep/).
+
+Usage:
+
+```javascript
+const crossOriginOpenerPolicy = require("cross-origin-opener-policy");
+
+// Sets "Cross-Origin-Opener-Policy: same-origin" (default)
+app.use(crossOriginOpenerPolicy());
+
+// Sets "Cross-Origin-Opener-Policy: unsafe-none" (same as not setting it)
+app.use(crossOriginOpenerPolicy({ policy: "unsafe-none" }));
+
+// Sets "Cross-Origin-Opener-Policy: same-origin-allow-popups"
+app.use(crossOriginOpenerPolicy({ policy: "same-origin-allow-popups" }));
+```


### PR DESCRIPTION
Created README and CHANGELOG for middlewares that configures Cross-Origin-Embedder-Policy and Cross-Origin-Opener-Policy. It's useful to understand how it works and the changes made there. =D