### PR TITLE
fix: types exports

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -51,7 +51,7 @@ export interface HelmetOptions {
   xssFilter?: boolean;
 }
 
-type MiddlewareFunction = (
+export type MiddlewareFunction = (
   req: IncomingMessage,
   res: ServerResponse,
   next: (error?: Error) => void
@@ -289,3 +289,7 @@ export {
   xPoweredBy as hidePoweredBy,
   xXssProtection as xssFilter,
 };
+
+export * from "./middlewares/content-security-policy/types";
+export * from "./middlewares/referrer-policy/types";
+export * from "./middlewares/strict-transport-security/types";

--- a/middlewares/content-security-policy/index.ts
+++ b/middlewares/content-security-policy/index.ts
@@ -1,41 +1,14 @@
 import { IncomingMessage, ServerResponse } from "http";
+import {
+  ContentSecurityPolicy,
+  ContentSecurityPolicyDirectiveValue,
+  ContentSecurityPolicyOptions,
+  NormalizedDirectives,
+  dangerouslyDisableDefaultSrc,
+  GetDefaultDirectives,
+} from "./types";
 
-type ContentSecurityPolicyDirectiveValueFunction = (
-  req: IncomingMessage,
-  res: ServerResponse
-) => string;
-
-type ContentSecurityPolicyDirectiveValue =
-  | string
-  | ContentSecurityPolicyDirectiveValueFunction;
-
-export interface ContentSecurityPolicyOptions {
-  useDefaults?: boolean;
-  directives?: Record<
-    string,
-    | null
-    | Iterable<ContentSecurityPolicyDirectiveValue>
-    | typeof dangerouslyDisableDefaultSrc
-  >;
-  reportOnly?: boolean;
-}
-
-type NormalizedDirectives = Map<
-  string,
-  Iterable<ContentSecurityPolicyDirectiveValue>
->;
-
-interface ContentSecurityPolicy {
-  (options?: Readonly<ContentSecurityPolicyOptions>): (
-    req: IncomingMessage,
-    res: ServerResponse,
-    next: (err?: Error) => void
-  ) => void;
-  getDefaultDirectives: typeof getDefaultDirectives;
-  dangerouslyDisableDefaultSrc: typeof dangerouslyDisableDefaultSrc;
-}
-
-const dangerouslyDisableDefaultSrc = Symbol("dangerouslyDisableDefaultSrc");
+export * from "./types";
 
 const DEFAULT_DIRECTIVES: Record<
   string,
@@ -53,8 +26,9 @@ const DEFAULT_DIRECTIVES: Record<
   "style-src": ["'self'", "https:", "'unsafe-inline'"],
   "upgrade-insecure-requests": [],
 };
-
-const getDefaultDirectives = () => ({ ...DEFAULT_DIRECTIVES });
+const getDefaultDirectives: GetDefaultDirectives = () => ({
+  ...DEFAULT_DIRECTIVES,
+});
 
 const dashify = (str: string): string =>
   str.replace(/[A-Z]/g, (capitalLetter) => "-" + capitalLetter.toLowerCase());

--- a/middlewares/content-security-policy/types.ts
+++ b/middlewares/content-security-policy/types.ts
@@ -1,0 +1,45 @@
+import { IncomingMessage, ServerResponse } from "http";
+
+export const dangerouslyDisableDefaultSrc = Symbol(
+  "dangerouslyDisableDefaultSrc"
+);
+
+export type GetDefaultDirectives = () => Record<
+  string,
+  Iterable<ContentSecurityPolicyDirectiveValue>
+>;
+
+export type ContentSecurityPolicyDirectiveValueFunction = (
+  req: IncomingMessage,
+  res: ServerResponse
+) => string;
+
+export type ContentSecurityPolicyDirectiveValue =
+  | string
+  | ContentSecurityPolicyDirectiveValueFunction;
+
+export interface ContentSecurityPolicyOptions {
+  useDefaults?: boolean;
+  directives?: Record<
+    string,
+    | null
+    | Iterable<ContentSecurityPolicyDirectiveValue>
+    | typeof dangerouslyDisableDefaultSrc
+  >;
+  reportOnly?: boolean;
+}
+
+export type NormalizedDirectives = Map<
+  string,
+  Iterable<ContentSecurityPolicyDirectiveValue>
+>;
+
+export interface ContentSecurityPolicy {
+  (options?: Readonly<ContentSecurityPolicyOptions>): (
+    req: IncomingMessage,
+    res: ServerResponse,
+    next: (err?: Error) => void
+  ) => void;
+  getDefaultDirectives: GetDefaultDirectives;
+  dangerouslyDisableDefaultSrc: typeof dangerouslyDisableDefaultSrc;
+}

--- a/middlewares/referrer-policy/index.ts
+++ b/middlewares/referrer-policy/index.ts
@@ -1,19 +1,7 @@
 import { IncomingMessage, ServerResponse } from "http";
+import { ReferrerPolicyOptions, ReferrerPolicyToken } from "./types";
 
-type ReferrerPolicyToken =
-  | "no-referrer"
-  | "no-referrer-when-downgrade"
-  | "same-origin"
-  | "origin"
-  | "strict-origin"
-  | "origin-when-cross-origin"
-  | "strict-origin-when-cross-origin"
-  | "unsafe-url"
-  | "";
-
-export interface ReferrerPolicyOptions {
-  policy?: ReferrerPolicyToken | ReferrerPolicyToken[];
-}
+export * from "./types";
 
 const ALLOWED_TOKENS = new Set<ReferrerPolicyToken>([
   "no-referrer",

--- a/middlewares/referrer-policy/types.ts
+++ b/middlewares/referrer-policy/types.ts
@@ -1,0 +1,14 @@
+export type ReferrerPolicyToken =
+  | "no-referrer"
+  | "no-referrer-when-downgrade"
+  | "same-origin"
+  | "origin"
+  | "strict-origin"
+  | "origin-when-cross-origin"
+  | "strict-origin-when-cross-origin"
+  | "unsafe-url"
+  | "";
+
+export interface ReferrerPolicyOptions {
+  policy?: ReferrerPolicyToken | ReferrerPolicyToken[];
+}

--- a/middlewares/strict-transport-security/index.ts
+++ b/middlewares/strict-transport-security/index.ts
@@ -1,12 +1,9 @@
 import { IncomingMessage, ServerResponse } from "http";
+import { StrictTransportSecurityOptions } from "./types";
+
+export * from "./types";
 
 const DEFAULT_MAX_AGE = 180 * 24 * 60 * 60;
-
-export interface StrictTransportSecurityOptions {
-  maxAge?: number;
-  includeSubDomains?: boolean;
-  preload?: boolean;
-}
 
 function parseMaxAge(value: number = DEFAULT_MAX_AGE): number {
   if (value >= 0 && Number.isFinite(value)) {

--- a/middlewares/strict-transport-security/types.ts
+++ b/middlewares/strict-transport-security/types.ts
@@ -1,0 +1,5 @@
+export interface StrictTransportSecurityOptions {
+  maxAge?: number;
+  includeSubDomains?: boolean;
+  preload?: boolean;
+}


### PR DESCRIPTION
Moves types into separate files so they can be exported with the package. This allows users to utilize some of the underlying options interfaces instead of just the root `HelmetOptions`.