### PR TITLE
Support `unsafe-none` in COEP

### DIFF
--- a/middlewares/cross-origin-embedder-policy/index.ts
+++ b/middlewares/cross-origin-embedder-policy/index.ts
@@ -1,10 +1,14 @@
 import type { IncomingMessage, ServerResponse } from "http";
 
 export interface CrossOriginEmbedderPolicyOptions {
-  policy?: "require-corp" | "credentialless";
+  policy?: "require-corp" | "credentialless" | "unsafe-none";
 }
 
-const ALLOWED_POLICIES = new Set(["require-corp", "credentialless"]);
+const ALLOWED_POLICIES = new Set([
+  "require-corp",
+  "credentialless",
+  "unsafe-none",
+]);
 
 function getHeaderValueFromOptions({
   policy = "require-corp",

--- a/test/cross-origin-embedder-policy.test.ts
+++ b/test/cross-origin-embedder-policy.test.ts
@@ -18,13 +18,15 @@ describe("Cross-Origin-Embedder-Policy middleware", () => {
     );
   });
 
-  (["require-corp", "credentialless"] as const).forEach((policy) => {
-    it(`sets "Cross-Origin-Embedder-Policy: ${policy}" when told to`, async () => {
-      await check(crossOriginEmbedderPolicy({ policy }), {
-        "cross-origin-embedder-policy": policy,
+  (["require-corp", "credentialless", "unsafe-none"] as const).forEach(
+    (policy) => {
+      it(`sets "Cross-Origin-Embedder-Policy: ${policy}" when told to`, async () => {
+        await check(crossOriginEmbedderPolicy({ policy }), {
+          "cross-origin-embedder-policy": policy,
+        });
       });
-    });
-  });
+    },
+  );
 
   it("throws when setting the policy to an invalid value", () => {
     const invalidValues = [


### PR DESCRIPTION
`unsafe-none` is a valid value for `Cross-Origin-Embedder-Policy`, so add support for it.

Fixes #446.