### PR TITLE
Increase default Strict-Transport-Security maxAge to 1 year

### DIFF
--- a/middlewares/strict-transport-security/index.ts
+++ b/middlewares/strict-transport-security/index.ts
@@ -1,6 +1,6 @@
 import type { IncomingMessage, ServerResponse } from "http";
 
-const DEFAULT_MAX_AGE = 180 * 24 * 60 * 60;
+const DEFAULT_MAX_AGE = 365 * 24 * 60 * 60;
 
 export interface StrictTransportSecurityOptions {
   maxAge?: number;

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -35,7 +35,7 @@ describe("helmet", () => {
       "cross-origin-resource-policy": "same-origin",
       "origin-agent-cluster": "?1",
       "referrer-policy": "no-referrer",
-      "strict-transport-security": "max-age=15552000; includeSubDomains",
+      "strict-transport-security": "max-age=31536000; includeSubDomains",
       "x-content-type-options": "nosniff",
       "x-dns-prefetch-control": "off",
       "x-download-options": "noopen",

--- a/test/strict-transport-security.test.ts
+++ b/test/strict-transport-security.test.ts
@@ -3,10 +3,10 @@ import strictTransportSecurity from "../middlewares/strict-transport-security";
 
 describe("Strict-Transport-Security middleware", () => {
   it('by default, sets max-age to 180 days and adds "includeSubDomains"', async () => {
-    expect(15552000).toStrictEqual(180 * 24 * 60 * 60);
+    expect(31536000).toStrictEqual(365 * 24 * 60 * 60);
 
     const expectedHeaders = {
-      "strict-transport-security": "max-age=15552000; includeSubDomains",
+      "strict-transport-security": "max-age=31536000; includeSubDomains",
     };
 
     await check(strictTransportSecurity(), expectedHeaders);
@@ -45,20 +45,20 @@ describe("Strict-Transport-Security middleware", () => {
 
   it("disables subdomains with the includeSubDomains option", async () => {
     await check(strictTransportSecurity({ includeSubDomains: false }), {
-      "strict-transport-security": "max-age=15552000",
+      "strict-transport-security": "max-age=31536000",
     });
   });
 
   it("can enable preloading", async () => {
     await check(strictTransportSecurity({ preload: true }), {
       "strict-transport-security":
-        "max-age=15552000; includeSubDomains; preload",
+        "max-age=31536000; includeSubDomains; preload",
     });
   });
 
   it("can explicitly disable preloading", async () => {
     await check(strictTransportSecurity({ preload: false }), {
-      "strict-transport-security": "max-age=15552000; includeSubDomains",
+      "strict-transport-security": "max-age=31536000; includeSubDomains",
     });
   });
 


### PR DESCRIPTION
[Issue #457](https://github.com/helmetjs/helmet/issues/457)

- [x] Update maxAge value from 180 to 365 days
- [x] Update expected values in tests from 15552000 to 31536000