### PR TITLE
Strict transport security middleware error

### DIFF
--- a/middlewares/strict-transport-security/index.ts
+++ b/middlewares/strict-transport-security/index.ts
@@ -29,7 +29,7 @@ function getHeaderValueFromOptions(
     );
   }
   if ("includeSubdomains" in options) {
-    console.warn(
+    throw new Error(
       'Strict-Transport-Security middleware should use `includeSubDomains` instead of `includeSubdomains`. (The correct one has an uppercase "D".)',
     );
   }

--- a/test/strict-transport-security.test.ts
+++ b/test/strict-transport-security.test.ts
@@ -87,12 +87,9 @@ describe("Strict-Transport-Security middleware", () => {
   });
 
   it("logs a warning when using the mis-capitalized `includeSubdomains` parameter", () => {
-    jest.spyOn(console, "warn").mockImplementation(() => {});
-
-    strictTransportSecurity({ includeSubdomains: false } as any);
-
-    expect(console.warn).toHaveBeenCalledTimes(1);
-    expect(console.warn).toHaveBeenCalledWith(
+    expect(() =>
+      strictTransportSecurity({ includeSubdomains: false } as any),
+    ).toThrow(
       'Strict-Transport-Security middleware should use `includeSubDomains` instead of `includeSubdomains`. (The correct one has an uppercase "D".)',
     );
   });


### PR DESCRIPTION
[Issue #462](https://github.com/helmetjs/helmet/issues/462)

- [x] Replace `console.warn` with `throw new Error`
- [x] Update tests to expect error to be thrown rather than the console to warn