### PR TITLE
Support importing ESM from 'helmet/module'

### DIFF
--- a/README.md
+++ b/README.md
@@ -700,3 +700,15 @@ You can use this as standalone middleware with `app.use(helmet.xXssProtection())
 [MIME sniffing]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types#mime_sniffing
 [Clickjacking]: https://en.wikipedia.org/wiki/Clickjacking
 [XSS]: https://developer.mozilla.org/en-US/docs/Glossary/Cross-site_scripting
+
+## Alternative ESM import
+
+If you're encountering issues importing Helmet in an ESM project (notably TypeScript projects launched with `ts-node`), an altnerative import is available that may resolve the problem. Import the module from `"helmet/module"` instead of `"helmet"`. For example:
+
+```javascript
+import helmet from "helmet/module";
+
+const app = express();
+
+app.use(helmet());
+```

--- a/build/build-package.ts
+++ b/build/build-package.ts
@@ -244,8 +244,11 @@ async function buildPackageJson({
     ],
     engines: devPackageJson.engines,
     exports: {
-      ...(esm ? { import: "./index.mjs" } : {}),
-      require: "./index.cjs",
+      ".": {
+        ...(esm ? { import: "./index.mjs" } : {}),
+        require: "./index.cjs",
+      },
+      ...(esm ? { "./module": "./index.mjs" } : {}),
     },
     // All supported versions of Node handle `exports`, but some build tools
     // still use `main`, so we keep it around.

--- a/test/project-setups/javascript-esm-alt-import/package.json
+++ b/test/project-setups/javascript-esm-alt-import/package.json
@@ -1,0 +1,7 @@
+{
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "helmet:test": "node test.js"
+  }
+}

--- a/test/project-setups/javascript-esm-alt-import/test.js
+++ b/test/project-setups/javascript-esm-alt-import/test.js
@@ -1,0 +1,40 @@
+import connect from "connect";
+import supertest from "supertest";
+import helmet, { frameguard } from "helmet/module";
+
+const handler = (_, res) => res.end("Hello world");
+
+async function testTopLevel() {
+  const app = connect().use(helmet()).use(handler);
+  await supertest(app)
+    .get("/")
+    .expect(200, "Hello world")
+    .expect("x-download-options", "noopen");
+}
+
+async function testImportedMiddleware() {
+  const app = connect().use(frameguard()).use(handler);
+  await supertest(app)
+    .get("/")
+    .expect(200, "Hello world")
+    .expect("x-frame-options", "SAMEORIGIN");
+}
+
+async function testAttachedMiddleware() {
+  const app = connect().use(helmet.frameguard()).use(handler);
+  await supertest(app)
+    .get("/")
+    .expect(200, "Hello world")
+    .expect("x-frame-options", "SAMEORIGIN");
+}
+
+async function main() {
+  await testTopLevel();
+  await testImportedMiddleware();
+  await testAttachedMiddleware();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/test/project-setups/typescript-esnext-alt-import/package.json
+++ b/test/project-setups/typescript-esnext-alt-import/package.json
@@ -1,0 +1,7 @@
+{
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "helmet:test": "tsx test.ts"
+  }
+}

--- a/test/project-setups/typescript-esnext-alt-import/test.ts
+++ b/test/project-setups/typescript-esnext-alt-import/test.ts
@@ -1,0 +1,43 @@
+import type { IncomingMessage, ServerResponse } from "http";
+import connect from "connect";
+import supertest from "supertest";
+import helmet, { frameguard } from "helmet/module";
+
+const handler = (_: IncomingMessage, res: ServerResponse) => {
+  res.end("Hello world");
+};
+
+async function testTopLevel() {
+  const app = connect().use(helmet()).use(handler);
+  await supertest(app)
+    .get("/")
+    .expect(200, "Hello world")
+    .expect("x-download-options", "noopen");
+}
+
+async function testImportedMiddleware() {
+  const app = connect().use(frameguard()).use(handler);
+  await supertest(app)
+    .get("/")
+    .expect(200, "Hello world")
+    .expect("x-frame-options", "SAMEORIGIN");
+}
+
+async function testAttachedMiddleware() {
+  const app = connect().use(helmet.frameguard()).use(handler);
+  await supertest(app)
+    .get("/")
+    .expect(200, "Hello world")
+    .expect("x-frame-options", "SAMEORIGIN");
+}
+
+async function main() {
+  await testTopLevel();
+  await testImportedMiddleware();
+  await testAttachedMiddleware();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/test/project-setups/typescript-esnext-alt-import/tsconfig.json
+++ b/test/project-setups/typescript-esnext-alt-import/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "node"
+  }
+}

--- a/test/project-setups/typescript-nodenext-esm-alt-import/package.json
+++ b/test/project-setups/typescript-nodenext-esm-alt-import/package.json
@@ -1,0 +1,7 @@
+{
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "helmet:test": "tsx test.ts"
+  }
+}

--- a/test/project-setups/typescript-nodenext-esm-alt-import/test.ts
+++ b/test/project-setups/typescript-nodenext-esm-alt-import/test.ts
@@ -1,0 +1,43 @@
+import type { IncomingMessage, ServerResponse } from "http";
+import connect from "connect";
+import supertest from "supertest";
+import helmet, { frameguard } from "helmet/module";
+
+const handler = (_: IncomingMessage, res: ServerResponse) => {
+  res.end("Hello world");
+};
+
+async function testTopLevel() {
+  const app = connect().use(helmet()).use(handler);
+  await supertest(app)
+    .get("/")
+    .expect(200, "Hello world")
+    .expect("x-download-options", "noopen");
+}
+
+async function testImportedMiddleware() {
+  const app = connect().use(frameguard()).use(handler);
+  await supertest(app)
+    .get("/")
+    .expect(200, "Hello world")
+    .expect("x-frame-options", "SAMEORIGIN");
+}
+
+async function testAttachedMiddleware() {
+  const app = connect().use(helmet.frameguard()).use(handler);
+  await supertest(app)
+    .get("/")
+    .expect(200, "Hello world")
+    .expect("x-frame-options", "SAMEORIGIN");
+}
+
+async function main() {
+  await testTopLevel();
+  await testImportedMiddleware();
+  await testAttachedMiddleware();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/test/project-setups/typescript-nodenext-esm-alt-import/tsconfig.json
+++ b/test/project-setups/typescript-nodenext-esm-alt-import/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "module": "nodenext",
+    "moduleResolution": "nodenext"
+  }
+}


### PR DESCRIPTION
- Make it possible to import the ES module from `helmet/module` to support older tools that don't well support conditional exports (e.g. `ts-node`).
  - Usage: `import helmet from 'helmet/module'`
  - This change is done in a backwards compatible way. Most users do not need to change their imports. Only users having trouble importing this module in their ESM projects due to outdated tooling can take advantage of the alternative import (that works with modern tooling as well).
- Duplicate ESM tests to ensure importing from `helmet/module` works as expected.

Fixes #474

**Note:** The duplicate ESM tests are probably overkill, but I figured I should err on the side of caution. I'm happy to remove them or shrink them.