### PR TITLE
Content-Security-Policy: better error when value should be quoted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+
+- `Content-Security-Policy` gives a better error when a directive value, like `self`, should be quoted. See [#482](https://github.com/helmetjs/helmet/issues/482)
+
 ## 8.0.0
 
 ### Changed


### PR DESCRIPTION
It's easy to forget to quote directive value entries like `'self'` and `'none'`. Someone [recently ran into this][0] and was confused by the error message.

This makes the error message clearer by telling you that something needs to be quoted.

```diff
-...invalid directive value for "img-src"
+...invalid directive value for "img-src". "self" should be quoted
```

[0]: https://github.com/helmetjs/helmet/issues/482