### PR TITLE
Pin github actions to commit-hash

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -14,10 +14,10 @@ jobs:
         node-version: [18.x, 20.x, 22.x]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:
           node-version: ${{ matrix.node-version }}
           check-latest: true


### PR DESCRIPTION
Follow the recent compromise of [tj-actions/changed-files](https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised), this PR pins GitHub actions to specific commit hashes to ensure a known version of each action is used, mitigating the risk of a supply chain attack through malicious updates.

[See related blog post by rafaelgss about pinning to the commit-hash](https://blog.rafaelgss.dev/why-you-should-pin-actions-by-commit-hash).