### PR TITLE
ci(nodejs): ignore scripts

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           check-latest: true
-      - run: npm ci
+      - run: npm ci --ignore-scripts
       - run: npm test
         env:
           CI: true


### PR DESCRIPTION
This PR adds the `--ignore-scripts` arg to disable the execution of any run scripts by third-party packages.

See https://snyk.io/blog/npm-security-preventing-supply-chain-attacks/.