### PR TITLE
Use tags for immutable github actions

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -14,10 +14,10 @@ jobs:
         node-version: [18.x, 20.x, 22.x, 24.x]
 
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           check-latest: true


### PR DESCRIPTION
Most first party actions now use https://github.com/actions/publish-immutable-action, which negates the need for commit hashes.

Apologies, missed this with my previous PR when changing these to hashes and only after talking to a GitHub developer did I discover this!