### PR TITLE
docs(x-frame-options): add inline documentation

### DIFF
--- a/middlewares/x-frame-options/index.ts
+++ b/middlewares/x-frame-options/index.ts
@@ -1,9 +1,21 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 
+// Middleware to set the X-Frame-Options header
+// Used to reduce clickjacking risks in browsers that do not support CSP
+// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options
+
+// Accepts only standardized values (RFC 7034): "DENY" and "SAMEORIGIN"
+// Default value: "SAMEORIGIN". The legacy "ALLOW-FROM" option is not supported
+// https://datatracker.ietf.org/doc/html/rfc7034
 export interface XFrameOptionsOptions {
   action?: "deny" | "sameorigin";
 }
 
+// Normalizes and validates the X-Frame-Options header value.
+// Converts to uppercase (tolerates different casing)
+// Accepts only safe values: "DENY" or "SAMEORIGIN"
+// Supports "SAME-ORIGIN" for backward compatibility with legacy configurations
+// Throws an error if the value is invalid, preventing insecure configuration
 function getHeaderValueFromOptions({
   action = "sameorigin",
 }: Readonly<XFrameOptionsOptions>): string {
@@ -11,7 +23,7 @@ function getHeaderValueFromOptions({
     typeof action === "string" ? action.toUpperCase() : action;
 
   switch (normalizedAction) {
-    case "SAME-ORIGIN":
+    case "SAME-ORIGIN": // legacy format support
       return "SAMEORIGIN";
     case "DENY":
     case "SAMEORIGIN":
@@ -23,6 +35,8 @@ function getHeaderValueFromOptions({
   }
 }
 
+// Middleware that sets the X-Frame-Options header in HTTP responses.
+// Returns a function in Express/Connect middleware format.
 function xFrameOptions(options: Readonly<XFrameOptionsOptions> = {}) {
   const headerValue = getHeaderValueFromOptions(options);
 


### PR DESCRIPTION
This time I aimed to add more complete documentation to the xFrameOptions middleware, explaining more clearly what it does and why it is important. I researched official sources (MDN and RFC 7034) to better understand the topic and included these references directly in the code, so that anyone working on it in the future has something to rely on.