### PR TITLE
update package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "helmet",
       "version": "8.1.0",
       "devDependencies": {
         "@eslint/js": "^9.31.0",


### PR DESCRIPTION
It looks like `package-lock.json` may not be up to date.

I noticed that the name field was removed from package.json in the following commit:
https://github.com/helmetjs/helmet/commit/a7091021198d0dd39f81030894f13281800477d0