### PR TITLE
Allow `Content-Security-Policy` and `Content-Security-Policy-Report-Only` to be set simultaneously

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,25 @@ app.use(
 );
 ```
 
+If you want to set _both_ the `Content-Security-Policy` and `Content-Security-Policy-Report-Only` headers simultaneously, you can do this:
+
+```javascript
+app.use(
+  helmet({
+    contentSecurityPolicy: {
+      directives: {
+        defaultSrc: ["'self'", "normal.example"],
+      },
+      reportOnly: {
+        directives: {
+          defaultSrc: ["'self'", "report-only.example"],
+        },
+      },
+    },
+  }),
+);
+```
+
 `upgrade-insecure-requests`, a directive that causes browsers to upgrade HTTP to HTTPS, is set by default. You may wish to avoid this in development, as you may not be developing with HTTPS. Notably, Safari will upgrade `http://localhost` to `https://localhost`, which can cause problems. To work around this, you may wish to disable the `upgrade-insecure-requests` directive in development. For example:
 
 ```js

--- a/middlewares/content-security-policy/README.md
+++ b/middlewares/content-security-policy/README.md
@@ -89,6 +89,23 @@ app.use(
 );
 ```
 
+If you want to set _both_ the `Content-Security-Policy` and `Content-Security-Policy-Report-Only` headers simultaneously, you can do this:
+
+```javascript
+app.use(
+  contentSecurityPolicy({
+    directives: {
+      defaultSrc: ["'self'", "normal.example"],
+    },
+    reportOnly: {
+      directives: {
+        defaultSrc: ["'self'", "report-only.example"],
+      },
+    },
+  }),
+);
+```
+
 `upgrade-insecure-requests`, a directive that causes browsers to upgrade HTTP to HTTPS, is set by default. You may wish to avoid this in development, as you may not be developing with HTTPS. Notably, Safari will upgrade `http://localhost` to `https://localhost`, which can cause problems. To work around this, you may wish to disable the `upgrade-insecure-requests` directive in development. For example:
 
 ```js

--- a/test/content-security-policy.test.ts
+++ b/test/content-security-policy.test.ts
@@ -312,7 +312,7 @@ describe("Content-Security-Policy middleware", () => {
     });
   });
 
-  it('can set the "report only" version of the header instead', async () => {
+  it('can set the "report only" version of the header instead, by specifying directives and reportOnly: true', async () => {
     await checkCsp({
       middlewareArgs: [
         {
@@ -325,6 +325,140 @@ describe("Content-Security-Policy middleware", () => {
       ],
       expectedDirectives: null,
       expectedReportOnlyDirectives: ["default-src 'self'"],
+    });
+  });
+
+  it('can set the "report only" version of the header instead, by only specifying reportOnly options', async () => {
+    await checkCsp({
+      middlewareArgs: [
+        {
+          reportOnly: {
+            useDefaults: false,
+            directives: {
+              "default-src": "'self'",
+            },
+          },
+        },
+      ],
+      expectedDirectives: null,
+      expectedReportOnlyDirectives: ["default-src 'self'"],
+    });
+    await checkCsp({
+      middlewareArgs: [
+        {
+          useDefaults: false,
+          reportOnly: {
+            directives: {
+              "default-src": "'self'",
+            },
+          },
+        },
+      ],
+      expectedDirectives: null,
+      expectedReportOnlyDirectives: ["default-src 'self'"],
+    });
+    await checkCsp({
+      middlewareArgs: [
+        {
+          reportOnly: {
+            directives: {
+              "default-src": "'self' foo.example",
+            },
+          },
+        },
+      ],
+      expectedDirectives: null,
+      expectedReportOnlyDirectives: [
+        "default-src 'self' foo.example",
+        "base-uri 'self'",
+        "font-src 'self' https: data:",
+        "form-action 'self'",
+        "frame-ancestors 'self'",
+        "img-src 'self' data:",
+        "object-src 'none'",
+        "script-src 'self'",
+        "script-src-attr 'none'",
+        "style-src 'self' https: 'unsafe-inline'",
+        "upgrade-insecure-requests",
+      ],
+    });
+    await checkCsp({
+      middlewareArgs: [
+        {
+          useDefaults: false,
+          reportOnly: {
+            useDefaults: true,
+            directives: {
+              "default-src": "'self' foo.example",
+            },
+          },
+        },
+      ],
+      expectedDirectives: null,
+      expectedReportOnlyDirectives: [
+        "default-src 'self' foo.example",
+        "base-uri 'self'",
+        "font-src 'self' https: data:",
+        "form-action 'self'",
+        "frame-ancestors 'self'",
+        "img-src 'self' data:",
+        "object-src 'none'",
+        "script-src 'self'",
+        "script-src-attr 'none'",
+        "style-src 'self' https: 'unsafe-inline'",
+        "upgrade-insecure-requests",
+      ],
+    });
+  });
+
+  it('can set both the "normal" and "report only" versions of the header simultaneously', async () => {
+    await checkCsp({
+      middlewareArgs: [
+        {
+          useDefaults: false,
+          directives: {
+            "default-src": "normal.example",
+          },
+          reportOnly: {
+            useDefaults: false,
+            directives: {
+              "default-src": "report.example",
+            },
+          },
+        },
+      ],
+      expectedDirectives: ["default-src normal.example"],
+      expectedReportOnlyDirectives: ["default-src report.example"],
+    });
+    await checkCsp({
+      middlewareArgs: [
+        {
+          useDefaults: false,
+          directives: {
+            "default-src": "normal.example",
+          },
+          reportOnly: {
+            useDefaults: true,
+            directives: {
+              "default-src": "report.example",
+            },
+          },
+        },
+      ],
+      expectedDirectives: ["default-src normal.example"],
+      expectedReportOnlyDirectives: [
+        "default-src report.example",
+        "base-uri 'self'",
+        "font-src 'self' https: data:",
+        "form-action 'self'",
+        "frame-ancestors 'self'",
+        "img-src 'self' data:",
+        "object-src 'none'",
+        "script-src 'self'",
+        "script-src-attr 'none'",
+        "style-src 'self' https: 'unsafe-inline'",
+        "upgrade-insecure-requests",
+      ],
     });
   });
 


### PR DESCRIPTION
_You may wish to [review this one commit at a time](https://github.com/helmetjs/helmet/pull/506/commits)._

See #351.