### PR TITLE
Readme: Add direkt FAQ link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ app.use(helmet());
 This will set 13 HTTP response headers in your app.
 
 [Helmet can also be used in standalone Node.js, or with other frameworks.](https://helmetjs.github.io/faq/use-without-express/)
+See [the docs](https://helmetjs.github.io/) for more info; your questions
+may already be answered in the [FAQ](https://helmetjs.github.io/faq/).
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -14,9 +14,7 @@ app.use(helmet());
 
 This will set 13 HTTP response headers in your app.
 
-[Helmet can also be used in standalone Node.js, or with other frameworks.](https://helmetjs.github.io/faq/use-without-express/)
-See [the docs](https://helmetjs.github.io/) for more info; your questions
-may already be answered in the [FAQ](https://helmetjs.github.io/faq/).
+See [the docs](https://helmetjs.github.io/) for more info, including [the FAQ](https://helmetjs.github.io/faq/).
 
 ## Configuration
 


### PR DESCRIPTION
Currently, if I search https://github.com/helmetjs/helmet for "faq" or "question", there's no match at all.